### PR TITLE
Fixing Issue #353 Capture config users&roles by name

### DIFF
--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1051,14 +1051,8 @@ private
       # TODO: include dav, xdbc, odbc servers?
       servers = quote_arglist(find_arg(['--servers']) || "#{@properties["ml.app-name"]}")
       mimes = quote_arglist(find_arg(['--mime-types']) || "##none##")
-
-      # setup.xqy expects ids for users and roles, unfortunately
-      #users = quote_arglist(find_arg(['--users'])) || '9999999'
-      #roles = quote_arglist(find_arg(['--roles'])) || '9999999'
-      # TODO: fix setup.xqy to (also) accept users/roles by name
-      # TODO: add app-user, default-user, and app-role as defaults
-      users = '9999999' # non-existing id
-      roles = '9999999' # non-existing id
+      users = quote_arglist(find_arg(['--users']) || "#{@properties["ml.app-name-user"]},#{@properties["ml.default-user"]}")
+      roles = quote_arglist(find_arg(['--roles']) || "#{@properties["ml.app-role"]}")
     end
 
     logger.info "Capturing configuration of MarkLogic on #{@hostname}..."
@@ -1074,7 +1068,7 @@ private
     else
       name = "#{@properties["ml.config.file"].sub( %r{.xml}, '' )}-#{@properties["ml.environment"]}.xml"
       File.open(name, 'wb') { |file| file.write(r.body) }
-      logger.info("... Captured full configuration into #{name}")
+      logger.info("... Captured configuration into #{name}")
       return true
     end
   end

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1076,9 +1076,15 @@ private
   def quote_arglist(arglist)
     if arglist != nil
       # TODO: remove duplicates
+      # TODO: what happens when strings and numbers are combined as arguments?
       args = arglist.split(/[,]+/).reject { |arg| arg.empty? }
-      arglist = args.join("\",\"")
-      return "\"#{arglist}\""
+      if !/\A\d+\z/.match(args[0])
+        arglist = args.join("\",\"")
+        return "\"#{arglist}\""
+      else
+        arglist = args.join(",")
+        return "#{arglist}"
+      end  
     end
   end
 

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4562,7 +4562,7 @@ declare function setup:get-privilege-by-name($name as xs:string) as element(sec:
 declare function setup:get-users-by-name($names as xs:string*) as element(sec:users)? {
   let $ids :=
     for $name in $names
-      return setup:get-user-id($name)
+      return xdmp:user($name)
   return setup:get-users($ids)
 };
 
@@ -4633,7 +4633,7 @@ declare function setup:get-user-id($user-name as xs:string) as xs:unsignedLong? 
 declare function setup:get-roles-by-name($roles as xs:string*) as element(sec:roles)? {
   let $ids :=
     for $role in $roles
-      return setup:get-role-id($role)
+      return xdmp:role($role)
   return setup:get-roles($ids)
 };
 
@@ -4690,17 +4690,6 @@ declare function setup:get-roles($ids as xs:unsignedLong*) as element(sec:roles)
           }
         }
     }</roles>
-};
-
-declare function setup:get-role-id($role-name as xs:string) as xs:unsignedLong? {
-  xdmp:eval(
-    'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
-     declare variable $role-name as xs:string external;
-     /sec:role[sec:role-name = $role-name]/sec:role-id',
-     (xs:QName("role-name"), $role-name),
-     <options xmlns="xdmp:eval">
-       <database>{$default-security}</database>
-     </options>)
 };
 
 declare function setup:get-external-securities($names as xs:string*) as element(sec:external-securities)*

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4562,8 +4562,15 @@ declare function setup:get-privilege-by-name($name as xs:string) as element(sec:
 declare function setup:get-users-by-name($names as xs:string*) as element(sec:users)? {
   let $ids :=
     for $name in $names
-      return xdmp:user($name)
-  return setup:get-users($ids)
+      return setup:get-users-by-name-helper($name)
+   return setup:get-users($ids)
+};
+
+declare function setup:get-users-by-name-helper($name as xs:string*) as xs:integer? {
+  try{
+    xdmp:user($name)
+  } catch($e) {
+  }
 };
 
 declare function setup:get-users($ids as xs:unsignedLong*) as element(sec:users)? {
@@ -4633,8 +4640,15 @@ declare function setup:get-user-id($user-name as xs:string) as xs:unsignedLong? 
 declare function setup:get-roles-by-name($roles as xs:string*) as element(sec:roles)? {
   let $ids :=
     for $role in $roles
-      return xdmp:role($role)
+      return setup:get-roles-by-name-helper($role)
   return setup:get-roles($ids)
+};
+
+declare function setup:get-roles-by-name-helper($role as xs:string*) as xs:integer? {
+  try{
+    xdmp:role($role)
+  } catch($e) {
+  }
 };
 
 declare function setup:get-roles($ids as xs:unsignedLong*) as element(sec:roles)? {

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4282,18 +4282,33 @@ declare function setup:get-configuration(
   $databases as xs:string*,
   $forests as xs:string*,
   $app-servers as xs:string*,
-  $user-ids as xs:unsignedLong*,
-  $role-ids as xs:unsignedLong*,
+  $users as xs:anySimpleType*,
+  $roles as xs:anySimpleType*,
   $mimetypes as xs:string*) as element()
 {
-  <configuration>
-    {setup:get-app-servers($app-servers)}
-    {setup:get-forests($forests)}
-    {setup:get-databases($databases)}
-    {setup:get-users($user-ids)}
-    {setup:get-roles($role-ids)}
-    {setup:get-mimetypes($mimetypes)}
-  </configuration>
+  let $user-configuration :=
+      typeswitch($users[1])
+        case xs:integer
+          return setup:get-users($users)
+        case xs:string
+          return setup:get-users-by-name($users)
+        default return setup:get-users(())
+  let $role-configuration :=
+      typeswitch($roles[1])
+        case xs:integer
+          return setup:get-roles($roles)
+        case xs:string
+          return setup:get-roles-by-name($roles)
+        default return setup:get-roles(())
+  return
+    <configuration>
+      {setup:get-app-servers($app-servers)}
+      {setup:get-forests($forests)}
+      {setup:get-databases($databases)}
+      {$user-configuration}
+      {$role-configuration}
+      {setup:get-mimetypes($mimetypes)}
+    </configuration>
 };
 
 declare function setup:get-app-servers($names as xs:string*) as element()*
@@ -4544,6 +4559,13 @@ declare function setup:get-privilege-by-name($name as xs:string) as element(sec:
     </options>)
 };
 
+declare function setup:get-users-by-name($names as xs:string*) as element(sec:users)? {
+  let $ids :=
+    for $name in $names
+      return setup:get-user-id($name)
+  return setup:get-users($ids)
+};
+
 declare function setup:get-users($ids as xs:unsignedLong*) as element(sec:users)? {
   let $users :=
     xdmp:eval(
@@ -4608,6 +4630,13 @@ declare function setup:get-user-id($user-name as xs:string) as xs:unsignedLong? 
      </options>)
 };
 
+declare function setup:get-roles-by-name($roles as xs:string*) as element(sec:roles)? {
+  let $ids :=
+    for $role in $roles
+      return setup:get-role-id($role)
+  return setup:get-roles($ids)
+};
+
 declare function setup:get-roles($ids as xs:unsignedLong*) as element(sec:roles)? {
   let $roles :=
     xdmp:eval(
@@ -4661,6 +4690,17 @@ declare function setup:get-roles($ids as xs:unsignedLong*) as element(sec:roles)
           }
         }
     }</roles>
+};
+
+declare function setup:get-role-id($role-name as xs:string) as xs:unsignedLong? {
+  xdmp:eval(
+    'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
+     declare variable $role-name as xs:string external;
+     /sec:role[sec:role-name = $role-name]/sec:role-id',
+     (xs:QName("role-name"), $role-name),
+     <options xmlns="xdmp:eval">
+       <database>{$default-security}</database>
+     </options>)
 };
 
 declare function setup:get-external-securities($names as xs:string*) as element(sec:external-securities)*


### PR DESCRIPTION
The setup:get-configuration function in setup.xqy used only ids to
return users and roles. This prevented the capture configurations
option from capturing users and roles specified by name in the
current project configuration or as a parameter. This was a
documented “TODO” in the code in order to improve the capture
functionality. The setup:get-configuration function will now take
user/role names or ids as a parameter and return the requested
configurations. Also added default users and roles from current
project to capture_environment_config in server_config.rb. Lastly
removed word “full” from logging since it could be a full or partial
configuration that is being captured.