### PR TITLE
Fixing Issue #223 Capture modules for any app type

### DIFF
--- a/deploy/lib/Help.rb
+++ b/deploy/lib/Help.rb
@@ -20,7 +20,7 @@ class Help
 
       Bootstrapping commands (with environment):
         bootstrap     Configures your application on the given environment
-        capture       Captures the source code of an existing App Builder application
+        capture       Captures the source code and if applicable the REST configuration of an existing application
         clean         Removes all files from the cpf, modules, or content databases on the given environment
         credentials   Configures user and password for the given environment
         info          Returns settings for the given environment
@@ -459,11 +459,17 @@ class Help
   def self.capture
     <<-DOC.strip_heredoc
       Usage: ml {env} capture --modules-db=[name of modules database]
+		Captures the source for an existing application
+		
+	  modules-db: (required)
+        The modules database of the application.
+	  
+	  ml {env} capture --app-builder=[name of Application Builder-based application]
         Captures the source and REST API configuration for an existing
         Application Builder-based application.
 
-      modules-db: (required)
-        The modules database of the App Builder application.
+      app-builder: (required)
+        The name of the App Builder application.
     DOC
   end
 


### PR DESCRIPTION
Currently Capture was only supporting capturing modules for
REST applications. I have added the ability to capture modules
for any application type to ML7 and taken the protection off
which will allow to capture modules for any application type in
ML5,6, and 7. For ML7 if it’s a REST application, REST will still be
used to perform the capture since it’s faster than the query
based method. The query based method used for ML5,6, and
ML7 (non-REST) only grabs text based files (xqy, html,…) it does
not correctly capture other types of files in the modules database
such as images since it’s doing an fn:doc on the URI to get the
content.