### PR TITLE
#410 implementation of testing SJS modules with SJS

### DIFF
--- a/src/test/default.xqy
+++ b/src/test/default.xqy
@@ -77,7 +77,7 @@ declare function t:list() {
       for $suite as xs:string in $suites
       let $tests as xs:string* :=
         if ($db-id = 0) then
-          xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xqy") | fn:ends-with(., ".sjs")]
+          xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xqy") or fn:ends-with(., ".sjs")]
         else
           let $uris := t:list-from-database(
             $db-id, $root, fn:concat($suite, '/'))


### PR DESCRIPTION
Allows tests like the one below. I'll add or update a wiki. 

    var test = require('/test/test-helper.xqy');
    var simple = require('/lib/simple.sjs');

    (function addOnePlusOne() {
      var actual = simple.addOne(1);
      xdmp.log('Ran addOnePlusOne');
      return [
        test.assertEqual(2, actual),
        test.assertNotEqual(5, actual)
      ];
    })();

    (function addOnePlusTwo() {
      var actual = simple.addOne(2);
      test.assertEqual(3, actual);
    })();
