### PR TITLE
Fixed #359: added separate mlcp user/pass properties

### DIFF
--- a/deploy/default.properties
+++ b/deploy/default.properties
@@ -201,6 +201,8 @@ local-server=localhost
 #
 mlcp-home=/usr/local/mlcp
 mlcp-vmargs=-Xmx512m
+mlcp-user=${user}
+mlcp-password=${password}
 
 #
 # Temporary fix to support MarkLogic 8 EA2

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -989,9 +989,11 @@ In order to proceed please type: #{expected_response}
       end
     end
 
+    @ml_username = @properties['ml.mlcp-user']
+    @ml_password = @properties['ml.mlcp-password']
     if ARGV.length > 0
       password_prompt
-      connection_string = %Q{ -username #{@properties['ml.user']} -password #{@ml_password} -host #{@properties['ml.server']} -port #{@properties['ml.xcc-port']}}
+      connection_string = %Q{ -username #{@ml_username} -password #{@ml_password} -host #{@properties['ml.server']} -port #{@properties['ml.xcc-port']}}
 
       args = ARGV.join(" ")
 

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -989,8 +989,8 @@ In order to proceed please type: #{expected_response}
       end
     end
 
-    @ml_username = @properties['ml.mlcp-user']
-    @ml_password = @properties['ml.mlcp-password']
+    @ml_username = @properties['ml.mlcp-user'] || @properties['ml.user']
+    @ml_password = @properties['ml.mlcp-password'] || @ml_password
     if ARGV.length > 0
       password_prompt
       connection_string = %Q{ -username #{@ml_username} -password #{@ml_password} -host #{@properties['ml.server']} -port #{@properties['ml.xcc-port']}}


### PR DESCRIPTION
Leveraging @ml_user and @ml_pass to make full use of password_prompt..