### PR TITLE
#511 corrected extension template

### DIFF
--- a/deploy/sample/rest-ext.sample.xqy
+++ b/deploy/sample/rest-ext.sample.xqy
@@ -5,8 +5,8 @@ module namespace yourNSAlias = "http://marklogic.com/rest-api/resource/extension
 declare namespace roxy = "http://marklogic.com/roxy";
 declare namespace rapi = "http://marklogic.com/rest-api";
 
-(: 
- : To add parameters to the functions, specify them in the params annotations. 
+(:
+ : To add parameters to the functions, specify them in the params annotations.
  : Example
  :   declare %roxy:params("uri=xs:string", "priority=xs:int") yourNSAlias:get(...)
  : This means that the get function will take two parameters, a string and an int.
@@ -22,7 +22,7 @@ function yourNSAlias:get(
 ) as document-node()*
 {
   map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-status", (200, "OK")),
   document { "GET called on the ext service extension" }
 };
 
@@ -37,7 +37,7 @@ function yourNSAlias:put(
 ) as document-node()?
 {
   map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-status", (201, "Created")),
   document { "PUT called on the ext service extension" }
 };
 
@@ -53,7 +53,7 @@ function yourNSAlias:post(
 ) as document-node()*
 {
   map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-status", (201, "Created")),
   document { "POST called on the ext service extension" }
 };
 
@@ -67,6 +67,6 @@ function yourNSAlias:delete(
 ) as document-node()?
 {
   map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-status", (200, "OK")),
   document { "DELETE called on the ext service extension" }
 };

--- a/deploy/sample/rest-ext.sample.xqy
+++ b/deploy/sample/rest-ext.sample.xqy
@@ -12,13 +12,12 @@ declare namespace rapi = "http://marklogic.com/rest-api";
  : This means that the get function will take two parameters, a string and an int.
  :
  : To report errors in your extension, use fn:error(). For details, see
- : http://docs.marklogic.com/guide/rest-dev/transforms#id_50497, but here's
+ : http://docs.marklogic.com/guide/rest-dev/extensions#id_33892, but here's
  : an example from the docs:
  : fn:error(
  :   (),
  :   "RESTAPI-SRVEXERR",
- :   ("415", "tsk tsk", "whoops")
- : )
+ :   ("415","Raven","nevermore"))
  :)
 
 (:

--- a/deploy/sample/rest-ext.sample.xqy
+++ b/deploy/sample/rest-ext.sample.xqy
@@ -12,12 +12,13 @@ declare namespace rapi = "http://marklogic.com/rest-api";
  : This means that the get function will take two parameters, a string and an int.
  :
  : To report errors in your extension, use fn:error(). For details, see
- : http://docs.marklogic.com/6.0/guide/rest-dev/transforms#id_50497, but here's
+ : http://docs.marklogic.com/guide/rest-dev/transforms#id_50497, but here's
  : an example from the docs:
  : fn:error(
  :   (),
- :   "RESTAPI-EXTNERR",
- :   ("415","Raven","xml",xdmp:quote(<word>nevermore</word>)))
+ :   "RESTAPI-SRVEXERR",
+ :   ("415", "tsk tsk", "whoops")
+ : )
  :)
 
 (:

--- a/deploy/sample/rest-ext.sample.xqy
+++ b/deploy/sample/rest-ext.sample.xqy
@@ -10,6 +10,14 @@ declare namespace rapi = "http://marklogic.com/rest-api";
  : Example
  :   declare %roxy:params("uri=xs:string", "priority=xs:int") yourNSAlias:get(...)
  : This means that the get function will take two parameters, a string and an int.
+ :
+ : To report errors in your extension, use fn:error(). For details, see
+ : http://docs.marklogic.com/6.0/guide/rest-dev/transforms#id_50497, but here's
+ : an example from the docs:
+ : fn:error(
+ :   (),
+ :   "RESTAPI-EXTNERR",
+ :   ("415","Raven","xml",xdmp:quote(<word>nevermore</word>)))
  :)
 
 (:


### PR DESCRIPTION
Response codes should be set in $context, not with xdmp:set-response-code().
http://docs.marklogic.com/guide/rest-dev/extensions#id_31884 #511