### PR TITLE
Capture/redirect on exit and provide unique return codes, fix for issue #543

### DIFF
--- a/deploy/lib/ml.rb
+++ b/deploy/lib/ml.rb
@@ -39,7 +39,7 @@ if @profile then
     RubyProf.start
   rescue LoadError
     print("Error: Please install the ruby-prof gem to enable profiling\n> gem install ruby-prof\n")
-    exit
+    exit 1
   end
 end
 
@@ -54,7 +54,7 @@ end
 
 if ARGV.length == 1 && need_help?
   Help.doHelp(@logger, :usage)
-  exit
+  exit 2
 end
 
 if RUBY_VERSION < "1.8.7"
@@ -125,7 +125,7 @@ begin
         ServerConfig.no_prompt = @no_prompt
         result = ServerConfig.send command
         if !result
-          exit!
+          exit 3
         end
       end
       break
@@ -154,7 +154,7 @@ begin
           :no_prompt => @no_prompt
         ).send(command)
         if !result
-          exit!
+          exit 4
         end
       else
         Help.doHelp(@logger, :usage, "Unknown command #{command}!")
@@ -166,32 +166,32 @@ rescue Net::HTTPServerException => e
   case e.response
   when Net::HTTPUnauthorized then
     @logger.error "Invalid login credentials for #{@properties["environment"]} environment!!"
-    exit!
+    exit 5
   else
     @logger.error e
     @logger.error e.response.body
-    exit!
+    exit 6
   end
 rescue Net::HTTPFatalError => e
   @logger.error e
   @logger.error e.response.body
-  exit!
+  exit 7
 rescue DanglingVarsException => e
   @logger.error "WARNING: The following configuration variables could not be validated:"
   e.vars.each do |k,v|
     @logger.error "#{k}=#{v}"
   end
-  exit!
+  exit 8
 rescue HelpException => e
   Help.doHelp(@logger, e.command, e.message)
-  exit!
+  exit 9
 rescue ExitException => e
   @logger.error e
-  exit!
+  exit 10
 rescue Exception => e
   @logger.error e
   @logger.error e.backtrace
-  exit!
+  exit 11
 end
 
 if @profile then

--- a/ml
+++ b/ml
@@ -155,7 +155,7 @@ then
 else
   if [ -e deploy/lib/ml.rb ]
   then
-    ruby -I deploy -I deploy/lib deploy/lib/ml.rb $* || exit 1
+    ruby -I deploy -I deploy/lib deploy/lib/ml.rb $* || exit $?
   else
     printf "\nERROR: You must run this command inside a valid Roxy Project. Use 'ml new' to create a project.\n\n"
     usage


### PR DESCRIPTION
### deploy/lib/ml.rb
***deploy/lib/ml.rb*** presently exits with errors using "exit!" This forces an immediate exit that bypasses [SystemExit](http://ruby-doc.org/core-1.9.3/SystemExit.html) handling and returns "1".  Using this method also causes something strange to happen with the output of the script, preventing redirection and other concerns [See: Issue #543](https://github.com/marklogic/roxy/issues/543)

**All "exit!" calls have been replaced with "exit #"** as I couldn't see any reason why the use of return codes would be problematic.  I believe this maintains all existing functionality, and is a desirable enhancement.

**Two "exit" calls were also replaced with a unique return code** THIS WILL CHANGE EXIT BEHAVIOR ("exit" alone will return 0).  Although I don't see any reason this addition would be undesired, I wanted to call it out since it does modify the return code.

More detail from Ruby docs:
[exit](http://ruby-doc.org/core-1.9.3/Kernel.html#method-i-exit) vs. [exit!](http://ruby-doc.org/core-1.9.3/Kernel.html#method-i-exit-21)
[SystemExit](http://ruby-doc.org/core-1.9.3/SystemExit.html)

###  ml
**ml** has been modified to exit with actual return code from deploy/lib/ml.rb instead of defaulting to 1