### PR TITLE
PREP to use constanst for exit codes

### DIFF
--- a/deploy/lib/ml.rb
+++ b/deploy/lib/ml.rb
@@ -20,6 +20,19 @@ require 'util'
 require 'upgrader'
 require 'scaffold'
 
+#Return Codes
+EXIT_LOAD_PROF_GEM = 3
+EXIT_SHOW_HELP = 0
+EXIT_SERVER_CONFIG_SEND = 4
+EXIT_SERVER_CONFIG_NEW = 5
+EXIT_RESCUE_HTTP_CREDS = 6
+EXIT_RESCUE_HTTP_ERROR = 7
+EXIT_RESCUE_HTTP_FATAL = 8
+EXIT_RESCUE_DANGLING_VARS = 9
+EXIT_RESCUE_HELP_EXCEPTION = 10
+EXIT_RESCUE_EXIT_EXCEPTION = 11
+EXIT_RESCUE_EXCPTION = 12
+
 if is_jar?
   require ServerConfig.expand_path("./deploy/app_specific")
 else
@@ -39,7 +52,7 @@ if @profile then
     RubyProf.start
   rescue LoadError
     print("Error: Please install the ruby-prof gem to enable profiling\n> gem install ruby-prof\n")
-    exit 1
+    exit EXIT_LOAD_PROF_GEM
   end
 end
 
@@ -54,7 +67,7 @@ end
 
 if ARGV.length == 1 && need_help?
   Help.doHelp(@logger, :usage)
-  exit 2
+  exit EXIT_SHOW_HELP
 end
 
 if RUBY_VERSION < "1.8.7"
@@ -125,7 +138,7 @@ begin
         ServerConfig.no_prompt = @no_prompt
         result = ServerConfig.send command
         if !result
-          exit 3
+          exit EXIT_SERVER_CONFIG_SEND
         end
       end
       break
@@ -154,7 +167,7 @@ begin
           :no_prompt => @no_prompt
         ).send(command)
         if !result
-          exit 4
+          exit EXIT_SERVER_CONFIG_NEW
         end
       else
         Help.doHelp(@logger, :usage, "Unknown command #{command}!")
@@ -166,32 +179,32 @@ rescue Net::HTTPServerException => e
   case e.response
   when Net::HTTPUnauthorized then
     @logger.error "Invalid login credentials for #{@properties["environment"]} environment!!"
-    exit 5
+    exit EXIT_RESCUE_HTTP_CREDS
   else
     @logger.error e
     @logger.error e.response.body
-    exit 6
+    exit EXIT_RESCUE_HTTP_ERROR
   end
 rescue Net::HTTPFatalError => e
   @logger.error e
   @logger.error e.response.body
-  exit 7
+  exit EXIT_RESCUE_HTTP_FATAL
 rescue DanglingVarsException => e
   @logger.error "WARNING: The following configuration variables could not be validated:"
   e.vars.each do |k,v|
     @logger.error "#{k}=#{v}"
   end
-  exit 8
+  exit EXIT_RESCUE_DANGLING_VARS
 rescue HelpException => e
   Help.doHelp(@logger, e.command, e.message)
-  exit 9
+  exit EXIT_RESCUE_HELP_EXCEPTION
 rescue ExitException => e
   @logger.error e
-  exit 10
+  exit EXIT_RESCUE_EXIT_EXCEPTION
 rescue Exception => e
   @logger.error e
   @logger.error e.backtrace
-  exit 11
+  exit EXIT_RESCUE_EXCPTION
 end
 
 if @profile then

--- a/deploy/lib/ml.rb
+++ b/deploy/lib/ml.rb
@@ -31,7 +31,7 @@ EXIT_RESCUE_HTTP_FATAL = 8
 EXIT_RESCUE_DANGLING_VARS = 9
 EXIT_RESCUE_HELP_EXCEPTION = 10
 EXIT_RESCUE_EXIT_EXCEPTION = 11
-EXIT_RESCUE_EXCPTION = 12
+EXIT_RESCUE_EXCEPTION = 12
 
 if is_jar?
   require ServerConfig.expand_path("./deploy/app_specific")
@@ -204,7 +204,7 @@ rescue ExitException => e
 rescue Exception => e
   @logger.error e
   @logger.error e.backtrace
-  exit EXIT_RESCUE_EXCPTION
+  exit EXIT_RESCUE_EXCEPTION
 end
 
 if @profile then

--- a/out.test
+++ b/out.test
@@ -1,1 +1,0 @@
-Ruby is required to run the ml scripts.

--- a/out.test
+++ b/out.test
@@ -1,0 +1,1 @@
+Ruby is required to run the ml scripts.


### PR DESCRIPTION
Follow up on comment by @dmcassel when working through https://github.com/marklogic/roxy/pull/546

It was easy for me with everything open to perform a few quick substitutions.  Past that, I attempted to confirm Ruby syntax but wasn't 100% sure I got it right.  I also don't have a good environment setup for testing this.  Having said that, if it doesn't work as-is, the placeholders are staged so it should be ready to go for any changes you would like to make.

  - replaced all hard-coded exit codes with constants
  - set usage to return 0 if help requested
  - shifted codes to avoided using reserved bash return codes
