### PR TITLE
Fix #551: Only load content that is newer locally than on the server

### DIFF
--- a/deploy/lib/Help.rb
+++ b/deploy/lib/Help.rb
@@ -248,10 +248,12 @@ class Help
       Usage: ml {env} deploy WHAT [options]
 
       General options:
-        -v, [--verbose]  # Verbose output
-        --batch=(yes|no) # enable or disable batch commit. By default
-                           batch is disabled for the local environment
-                           and enabled for all others.
+        -v, [--verbose]        # Verbose output
+        --batch=(yes|no)       # enable or disable batch commit. By default
+                                 batch is disabled for the local environment
+                                 and enabled for all others.
+        --incremental=(yes|no) # For content, only deploy files which are
+                                 newer locally than on the server
 
       Please choose a WHAT below.
 

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1387,12 +1387,13 @@ private
     end
 
     uris = files.map { |f| xcc.build_target_uri(f, options) }
+    uris_as_string = uris.map{|i| "\"#{i}\""}.join(",")
+    q = %Q{for $u in (#{uris_as_string}) return "" || xdmp:timestamp-to-wallclock(xdmp:document-timestamp($u))}
 
-    stamps_db = uris.map do |target_uri|
-      q = %Q{"" || xdmp:timestamp-to-wallclock(xdmp:document-timestamp("#{target_uri}"))}
-      result = execute_query q, :db_name => @properties["ml.content-db"]
-      parse_json(result.body)
-    end
+    result = execute_query q, :db_name => @properties["ml.content-db"]
+    stamps_db = parse_json(result.body).split("\n")
+
+    print stamps_db.class
 
     stamps_local = files.map { |file_uri| File.mtime(file_uri).getgm.iso8601(5).tr('Z','') }
 

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1387,14 +1387,7 @@ private
     end
 
     uris = files.map { |f| xcc.build_target_uri(f, options) }
-    uris_as_string = uris.map{|i| "\"#{i}\""}.join(",")
-    q = %Q{for $u in (#{uris_as_string}) return "" || xdmp:timestamp-to-wallclock(xdmp:document-timestamp($u))}
-
-    result = execute_query q, :db_name => @properties["ml.content-db"]
-    stamps_db = parse_json(result.body).split("\n")
-
-    print stamps_db.class
-
+    stamps_db = get_db_timestamps(uris)
     stamps_local = files.map { |file_uri| File.mtime(file_uri).getgm.iso8601(5).tr('Z','') }
 
     files_with_stamps = files.zip(stamps_local, stamps_db)
@@ -1411,6 +1404,14 @@ private
     end
 
     filtered.map { |f, stamp1, stamp2| f}
+  end
+
+  def get_db_timestamps(uris)
+    uris_as_string = uris.map{|i| "\"#{i}\""}.join(",")
+    q = %Q{for $u in (#{uris_as_string}) return "" || xdmp:timestamp-to-wallclock(xdmp:document-timestamp($u))}
+
+    result = execute_query q, :db_name => @properties["ml.content-db"]
+    parse_json(result.body).split("\n")
   end
 
   def save_files_to_fs(target_db, target_dir)

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1388,7 +1388,7 @@ private
 
     uris = files.map { |f| xcc.build_target_uri(f, options) }
     stamps_db = get_db_timestamps(uris)
-    stamps_local = files.map { |file_uri| File.mtime(file_uri).getgm.iso8601(5).tr('Z','') }
+    stamps_local = files.map { |file_uri| File.mtime(file_uri).getgm.iso8601(5) }
 
     files_with_stamps = files.zip(stamps_local, stamps_db)
 
@@ -1408,7 +1408,7 @@ private
 
   def get_db_timestamps(uris)
     uris_as_string = uris.map{|i| "\"#{i}\""}.join(",")
-    q = %Q{for $u in (#{uris_as_string}) return "" || xdmp:timestamp-to-wallclock(xdmp:document-timestamp($u))}
+    q = %Q{for $u in (#{uris_as_string}) return "" || adjust-dateTime-to-timezone(xdmp:timestamp-to-wallclock(xdmp:document-timestamp($u)), xs:dayTimeDuration("PT0H"))}
 
     result = execute_query q, :db_name => @properties["ml.content-db"]
     parse_json(result.body).split("\n")

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1382,6 +1382,10 @@ private
   def filter_to_newer_files(files, options)
     logger.info "Filtering to files which are newer locally than on the server"
 
+    if @server_version < 6
+      raise ExitException.new("Can only filter files on MarkLogic 6 and later")
+    end
+
     files.select { |file_uri|
       target_uri = xcc.build_target_uri(file_uri, options)
 

--- a/deploy/lib/util.rb
+++ b/deploy/lib/util.rb
@@ -102,6 +102,36 @@ def file_exists?(filename)
   end
 end
 
+def get_files(path, options = {}, data = [])
+  ignore_extensions = ['..', '.', '.svn', '.git', '.ds_store', 'thumbs.db']
+
+  if File.directory?(path)
+    Dir.foreach(path) do |entry|
+      next if ignore_extensions.include?(entry.downcase)
+      full_path = File.join(path, entry)
+      skip = false
+
+      options[:ignore_list].each do |ignore|
+        if full_path.match(ignore)
+          skip = true
+          break
+        end
+      end if options[:ignore_list]
+
+      next if skip == true
+
+      if File.directory?(full_path)
+        get_files(full_path, options, data)
+      else
+        data << full_path.encode("UTF-8")
+      end
+    end
+  else
+    data = [path.encode("UTF-8")]
+  end
+  data
+end
+
 class String
   unless respond_to? :try
     def try(method)
@@ -136,7 +166,7 @@ class Object
   def to_b
     present? && ['true', 'TRUE', 'yes', 'YES', 'y', 'Y', 't', 'T'].include?(self)
   end
-  
+
   def optional_require(feature)
     begin
       require feature

--- a/deploy/lib/xcc.rb
+++ b/deploy/lib/xcc.rb
@@ -158,13 +158,6 @@ module Roxy
       1
     end
 
-    private
-
-    def go(url, verb, headers = {}, params = nil, body = nil)
-      headers['User-Agent'] = "Roxy RubyXCC/#{RUBY_XCC_VERSION}  MarkXDBC/#{XCC_VERSION}"
-      super(url, verb, headers, params, body, true)
-    end
-
     def build_target_uri(file_uri, options)
       target_uri = file_uri.sub(options[:remove_prefix] || "", "")
       if options[:add_prefix]

--- a/deploy/lib/xcc.rb
+++ b/deploy/lib/xcc.rb
@@ -27,13 +27,13 @@ module Net
     def set_path(path)
       @path = path
     end
-    
+
     alias_method :original_write_header, :write_header
-    
+
     def use_xcc(bool)
       @use_xcc = bool
     end
-    
+
     def write_header(sock, ver, path)
       if @use_xcc
         buf = "#{@method} #{path} XDBC/1.0\r\n"
@@ -86,8 +86,6 @@ module Roxy
 
     attr_reader :hostname, :port
 
-    IGNORE_EXTENSIONS = ['..', '.', '.svn', '.git', '.ds_store', 'thumbs.db']
-
     def initialize(options)
       super(options)
       @hostname = options[:xcc_server]
@@ -116,34 +114,30 @@ module Roxy
       r = go "http://#{options[:host]}:#{options[:port]}/eval", "post", headers, params
     end
 
-    def load_files(path, options = {})
-      if File.exists?(path)
-        headers = {
-          'Content-Type' => "text/xml",
-          'Accept' => "text/html, text/xml, image/gif, image/jpeg, application/vnd.marklogic.sequence, application/vnd.marklogic.document, */*"
-        }
+    def load_files(files, options = {})
 
-        data = get_files(path, options)
-        size = data.size
+      headers = {
+        'Content-Type' => "text/xml",
+        'Accept' => "text/html, text/xml, image/gif, image/jpeg, application/vnd.marklogic.sequence, application/vnd.marklogic.document, */*"
+      }
 
-        batch_commit = options[:batch_commit] == true
-        logger.debug "Using Batch commit: #{batch_commit}"
-        data.each_with_index do |file_uri, i|
-          commit = ((false == batch_commit) || (i >= (size - 1)))
+      size = files.size
 
-          target_uri = build_target_uri(file_uri, options)
-          url = build_load_uri(target_uri, options, commit)
-          logger.debug "loading: #{file_uri} => #{target_uri}"
+      batch_commit = options[:batch_commit] == true
+      logger.debug "Using Batch commit: #{batch_commit}"
+      files.each_with_index do |file_uri, i|
+        commit = ((false == batch_commit) || (i >= (size - 1)))
 
-          r = go url, "put", headers, nil, prep_body(file_uri, commit)
-          logger.error(r.body) unless r.code.to_i == 200
-        end
+        target_uri = build_target_uri(file_uri, options)
+        url = build_load_uri(target_uri, options, commit)
+        logger.debug "loading: #{file_uri} => #{target_uri}"
 
-        return data.length
-      else
-        logger.error "#{path} does not exist"
+        r = go url, "put", headers, nil, prep_body(file_uri, commit)
+        logger.error(r.body) unless r.code.to_i == 200
       end
-      0
+
+      return files.length
+
     end
 
     def load_buffer(uri, buffer, options)
@@ -171,34 +165,6 @@ module Roxy
       super(url, verb, headers, params, body, true)
     end
 
-    def get_files(path, options = {}, data = [])
-      if File.directory?(path)
-        Dir.foreach(path) do |entry|
-          next if IGNORE_EXTENSIONS.include?(entry.downcase)
-          full_path = File.join(path, entry)
-          skip = false
-
-          options[:ignore_list].each do |ignore|
-            if full_path.match(ignore)
-              skip = true
-              break
-            end
-          end if options[:ignore_list]
-
-          next if skip == true
-
-          if File.directory?(full_path)
-            get_files(full_path, options, data)
-          else
-            data << full_path.encode("UTF-8")
-          end
-        end
-      else
-        data = [path.encode("UTF-8")]
-      end
-      data
-    end
-
     def build_target_uri(file_uri, options)
       target_uri = file_uri.sub(options[:remove_prefix] || "", "")
       if options[:add_prefix]
@@ -206,6 +172,13 @@ module Roxy
         target_uri = prefix + target_uri
       end
       target_uri
+    end
+
+private
+
+    def go(url, verb, headers = {}, params = nil, body = nil)
+      headers['User-Agent'] = "Roxy RubyXCC/#{RUBY_XCC_VERSION}  MarkXDBC/#{XCC_VERSION}"
+      super(url, verb, headers, params, body, true)
     end
 
     def build_load_uri(target_uri, options, commit)


### PR DESCRIPTION
This change adds support for a command line flag that causes "deploy content" to compare modification times on local files and timestamps on deployed documents. It then only deploys files which are new or have newer modification dates locally.

The use case is the situation where the deployed files are a "baseline" set that could potentially change in a running system.

~~It's not optimized for speed and will be slow if there's a large number of small files, as an individual timestamp query is done for each.~~