### PR TITLE
Fix test-helper assert-throws-error().

### DIFF
--- a/src/test/test-helper.xqy
+++ b/src/test/test-helper.xqy
@@ -278,37 +278,37 @@ declare function helper:assert-meets-maximum-threshold($expected as xs:decimal, 
 
 declare function helper:assert-throws-error($function as xdmp:function)
 {
-  helper:assert-throws-error($function, ())
+  helper:assert-throws-error_($function, json:to-array(), ())
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array(), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, $param1, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array( (json:to-array($param1), json:to-array('make me a sequence')), 1 ), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $param2 as item()*, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, $param1, $param2, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array((json:to-array($param1), json:to-array($param2))), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, $param1, $param2, $param3, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3))), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, $param1, $param2, $param3, $param4, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3), json:to-array($param4))), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $param5 as item()*, $error-code as xs:string?)
 {
-  helper:assert-throws-error($function, $param1, $param2, $param3, $param4, $param5, (), $error-code)
+  helper:assert-throws-error_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3), json:to-array($param4), json:to-array($param5))), $error-code)
 };
 
 declare function helper:assert-throws-error($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $param5 as item()*, $param6 as item()*, $error-code as xs:string?)


### PR DESCRIPTION
The original fix for #503 (#526) didn't work for me and all the unit tests using `assert-throws-error()` fail on my installation of ML 8.0.1-1.  This PR change works for my version of ML and should work on newer versions since it directly calls the wrapped helper rather than building a cascade of empty-sequence calls.

There is a quirk in json:to-array() in that it collapses the input into a single-dimension array when its arguments are a one element array.  This PR works around that quirk and allows a single virtualized vararg to be sent correctly.