### PR TITLE
Fix #571 Set the disabled style when loading /test

### DIFF
--- a/src/test/js/tests.js
+++ b/src/test/js/tests.js
@@ -343,6 +343,8 @@ $(document).ready(function(){
 
   $('input.cb').each(function() {
     if (this.id !== 'checkall') {
+      disableParent(this, 'tr');
+
       $(this).click(function(event) {
 
         disableParent(this, 'tr');
@@ -368,6 +370,8 @@ $(document).ready(function(){
   });
 
   $('input.test-cb').each(function() {
+    disableParent(this, 'li');
+
     $(this).click(function(event) {
       disableParent(this, 'li');
 


### PR DESCRIPTION
Call disableParent on each test and test suite on page load to ensure that the disabled style is correctly set to reflect the check state of the corresponding checkbox. #571