### PR TITLE
Fix #570 Update the disabled style after checkall in /test.

### DIFF
--- a/src/test/js/tests.js
+++ b/src/test/js/tests.js
@@ -338,6 +338,7 @@ $(document).ready(function(){
   $('#checkall').click(function(event){
     $('#tests tbody').find('input.cb').each(function(){
       $(this).attr('checked', $('#checkall').is(':checked'));
+      disableParent(this, 'tr');
     });
   });
 
@@ -363,6 +364,7 @@ $(document).ready(function(){
     var parentCheck = $(this);
     parentCheck.parent().next('ul.tests').find('input.test-cb').each(function() {
       $(this).attr('checked', parentCheck.is(':checked'));
+      disableParent(this, 'li');
     });
     parentCheck.parents('tr').prev('tr').find('input.cb').attr('checked', parentCheck.is(':checked'));
   });


### PR DESCRIPTION
This ensures that the disabled style is set correctly when the user toggles the run all tests and run all test suites checkboxes. #570