### PR TITLE
Fix #630 Don't include padding in the test result rows.

### DIFF
--- a/src/test/css/tests.css
+++ b/src/test/css/tests.css
@@ -98,6 +98,10 @@ table td {
   vertical-align: top;
 }
 
+table tr.tests td {
+  padding: 0;
+}
+
 tr.even {
   background-color: #dfd;
 }

--- a/src/test/default.xqy
+++ b/src/test/default.xqy
@@ -333,7 +333,7 @@ declare function local:main() {
                 <td class="passed">-</td>
                 <td class="right failed">-</td>
               </tr>,
-              <tr class="{$class}">
+              <tr class="{$class} tests">
                 <td colspan="6">
                 <div class="tests">
                   <div class="wrapper"><input class="check-all-tests" type="checkbox" checked="checked"/>Run All Tests</div>


### PR DESCRIPTION
This makes the bottom padding of rows consistent with the top, left and right padding. The additional bottom padding is due to the test results row. This fix has the effect makes the running tests border extend to the bottom of the row. #630