### PR TITLE
Improve get-test-file and get-modules-file document loading behaviour.

### DIFF
--- a/src/test/test-helper.xqy
+++ b/src/test/test-helper.xqy
@@ -60,11 +60,17 @@ declare function helper:get-caller()
 declare function helper:get-test-file($filename as xs:string)
   as document-node()
 {
+  helper:get-test-file($filename, "text")
+};
+
+declare function helper:get-test-file($filename as xs:string, $format as xs:string?)
+  as document-node()
+{
   helper:get-modules-file(
     fn:replace(
       fn:concat(
         cvt:basepath($helper:__CALLER_FILE__), "/test-data/", $filename),
-      "//", "/"))
+      "//", "/"), $format)
 };
 
 declare function helper:load-test-file($filename as xs:string, $database-id as xs:unsignedLong, $uri as xs:string)
@@ -109,14 +115,20 @@ declare function helper:build-uri(
 };
 
 declare function helper:get-modules-file($file as xs:string) {
+  helper:get-modules-file($file, "text")
+};
+
+declare function helper:get-modules-file($file as xs:string, $format as xs:string?) {
   if (xdmp:modules-database() eq 0) then
     let $doc :=
       xdmp:document-get(
         helper:build-uri(xdmp:modules-root(), $file),
-        (: TODO why insist on text? :)
-        <options xmlns="xdmp:document-get">
-          <format>text</format>
-        </options>)
+        if (fn:exists($format)) then
+          <options xmlns="xdmp:document-get">
+            <format>{$format}</format>
+          </options>
+        else
+          ())
     return
       try {
         xdmp:unquote($doc)


### PR DESCRIPTION
This keeps the `($filename)` version of these functions with the same behaviour as before this change, but introduces two new overloads that allow the behaviour to be customised:

1.  `get-test-file($filename, $format)` -- Loads $filename in the specified `xdmp:document-get` format (`text`, `binary`, `xml` or `json`). This does not unquote the resulting document.
2.  `get-test-file($filename, $format, $unquote)` -- As (1) but controls the unquoting behaviour (`()` for no unquoting, `force-unquote` for unquoting that swallows exceptions, and any other value to enable unquoting that does not swallow errors). __NOTE:__ The `force-unquote` value allows text documents, etc. to not throw an error.

For example:

    let $pdf := get-test-document("document.pdf", "binary")
    let $json := get-test-document("document.json", "json")