### PR TITLE
Fix #654: Handle conf:rewrite not being present in rest-api's config.xqy

### DIFF
--- a/src/roxy/rewrite.xqy
+++ b/src/roxy/rewrite.xqy
@@ -41,7 +41,7 @@ return
       (rewriter:rewrite($method, $uri, $path), $uri)[1]
     }
     catch($ex) {
-      if ($ex/error:code = "XDMP-MODNOTFOUND") then
+      if ($ex/error:code = "XDMP-MODNOTFOUND" or $ex/error:code = "XDMP-UNDFUN") then
         $uri
       else
         xdmp:rethrow()


### PR DESCRIPTION
This allows me to properly view the `/test/` page on my MarkLogic install using the Roxy rewrite logic and `routes` configuration.