### PR TITLE
Fix for issue #621

### DIFF
--- a/deploy/lib/util.rb
+++ b/deploy/lib/util.rb
@@ -145,7 +145,7 @@ class String
   end
 
   def xquery_safe
-    REXML::Text::normalize(self).gsub(/\{/, '{{').gsub(/\}/, '}}')
+    REXML::Text::normalize(self)
   end
 
   def xquery_unsafe


### PR DESCRIPTION
#621 

I tested this with a variety of passwords including many special characters such as `{ } >< \ /`

Ran many tests across Roxy and couldn't find any evidence that this breaks anything.

Simple fix but took me a couple evenings to study the codebase to find it and a couple more to thoroughly test it.

Partially fixes #622 but characters like `>` and `<` are still shown as escaped. Probably will need a separate PR for that.