### PR TITLE
#640: Support SJS with a language property

### DIFF
--- a/deploy/default.properties
+++ b/deploy/default.properties
@@ -14,6 +14,13 @@
 xquery.dir=${basedir}/src
 
 #
+# What type of language is the default for the controllers?
+# sjs - Serverside JavaScript
+# xqy - XQuery (default)
+#
+controller-ext=xqy
+
+#
 # MarkLogic application servers exist inside a group. ML Instances start off
 # with a group called "Default".
 #

--- a/src/app/config/config.xqy
+++ b/src/app/config/config.xqy
@@ -60,6 +60,18 @@ declare variable $c:ROXY-ROUTES :=
 
 (:
  : ***********************************************
+ : What is the default language of the controllers defined in the <request>
+ : sjs - Serverside JavaScript
+ : xqy - XQuery (default)
+ :
+ : Override this setting in the build.properties with the "controller-ext" key value pair.
+ :
+ : ***********************************************
+ :)
+declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[1];
+
+(:
+ : ***********************************************
  : A decent place to put your appservices search config
  : and various other search options.
  : The examples below are used by the appbuilder style

--- a/src/roxy/config/defaults.xqy
+++ b/src/roxy/config/defaults.xqy
@@ -89,6 +89,11 @@ declare variable $ROXY-ROUTES :=
     </routes>;
 
 (:
+ : Default controller language
+ :)
+declare variable $CTRL-EXT := "xqy";
+
+(:
  : ***********************************************
  : A decent place to put your appservices search config
  : and various other search options

--- a/src/roxy/router.xqy
+++ b/src/roxy/router.xqy
@@ -27,7 +27,7 @@ import module namespace u = "http://marklogic.com/roxy/util" at "/roxy/lib/util.
 declare option xdmp:mapping "false";
 
 declare variable $controller as xs:QName := req:get("controller", "type=xs:QName");
-declare variable $language as xs:string := req:get("language", "xqy", "type=xs:string");
+declare variable $language as xs:string := req:get("language", $config:CTRL-EXT, "type=xs:string");
 declare variable $controller-path as xs:string := fn:concat("/app/controllers/", $controller, ".", $language);
 declare variable $controller-ns as xs:string :=
   if ($language eq "xqy") then

--- a/src/roxy/router.xqy
+++ b/src/roxy/router.xqy
@@ -27,7 +27,14 @@ import module namespace u = "http://marklogic.com/roxy/util" at "/roxy/lib/util.
 declare option xdmp:mapping "false";
 
 declare variable $controller as xs:QName := req:get("controller", "type=xs:QName");
-declare variable $controller-path as xs:string := fn:concat("/app/controllers/", $controller, ".xqy");
+declare variable $language as xs:string := req:get("language", "xqy", "type=xs:string");
+declare variable $controller-path as xs:string := fn:concat("/app/controllers/", $controller, ".", $language);
+declare variable $controller-ns as xs:string :=
+  if ($language eq "xqy") then
+    fn:concat("http://marklogic.com/roxy/controller/", $controller)
+  else
+    "";
+
 declare variable $func as xs:string := req:get("func", "main", "type=xs:string");
 declare variable $default-format :=
   (
@@ -50,7 +57,7 @@ declare function router:route()
   let $data :=
     xdmp:apply(
       xdmp:function(
-        fn:QName(fn:concat("http://marklogic.com/roxy/controller/", $controller), $func),
+        fn:QName($controller-ns, $func),
         $controller-path))
 
   (: Roxy options :)


### PR DESCRIPTION
Add <uri-param name="language">sjs</uri-param> to your request
definition to make use of a SJS controller.
More comments added to Issue #640.