### PR TITLE
Issue 563

### DIFF
--- a/deploy/default.properties
+++ b/deploy/default.properties
@@ -14,6 +14,13 @@
 xquery.dir=${basedir}/src
 
 #
+# What type of language is the default for the controllers?
+# sjs - Serverside JavaScript
+# xqy - XQuery (default)
+#
+controller-ext=xqy
+
+#
 # MarkLogic application servers exist inside a group. ML Instances start off
 # with a group called "Default".
 #

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -2409,6 +2409,21 @@ private
     }
   end
 
+  def test_user_xml
+    %Q{
+      <user>
+        <user-name>${test-user}</user-name>
+        <description>A user for the ${app-name} unit tests</description>
+        <password>${test-user-password}</password>
+        <role-names>
+          <role-name>${app-role}-unit-test</role-name>
+        </role-names>
+        <permissions/>
+        <collections/>
+      </user>
+    }
+  end
+
   def test_modules_db_assignment
     %Q{
       <assignment>
@@ -2569,6 +2584,14 @@ private
     else
       config.gsub!("@ml.test-modules-db-xml", "")
       config.gsub!("@ml.test-modules-db-assignment", "")
+    end
+
+    if @properties['ml.test-user'].present?
+
+      config.gsub!("@ml.test-user-xml", test_user_xml)
+
+    else
+      config.gsub!("@ml.test-user-xml", "")
     end
 
     if @properties['ml.rest-port'].present?

--- a/deploy/sample/build.sample.properties
+++ b/deploy/sample/build.sample.properties
@@ -38,6 +38,14 @@ modules-prefix=/
 # test-content-db=${app-name}-content-test
 # test-modules-db=${app-name}-modules
 # test-port=8042
+
+# The unit tests that come with Roxy require some privileges that we might not
+# want to grant to all users. The ${app-name}-unit-test role has those
+# privileges and also inherits from ${app-name}-role. To create a user for the
+# testing role, uncomment the two following properties. You can also run unit
+# tests as admin.
+# test-user=${app-name}-test-user
+# test-user-password=random
 #
 # The authentication method used for your test appserver
 # application-level, basic, digest, digestbasic

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -458,6 +458,12 @@
       </collections>
       <privileges>
         <privilege>
+          <privilege-name>any-uri</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>rest-reader</privilege-name>
+        </privilege>
+        <privilege>
           <privilege-name>xdmp:value</privilege-name>
         </privilege>
         <privilege>
@@ -468,6 +474,41 @@
         </privilege>
         <privilege>
           <privilege-name>xdmp:with-namespaces</privilege-name>
+        </privilege>
+        <!-- START: required to run Roxy's rewriter-lib -->
+        <privilege>
+          <privilege-name>xdmp:get-server-field</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:set-server-field</privilege-name>
+        </privilege>
+        <!-- END: required to run Roxy's rewriter-lib -->
+      </privileges>
+    </role>
+    <role>
+      <role-name>${app-role}-unit-test</role-name>
+      <description>A role for unit testing the ${app-name} application</description>
+      <privileges>
+        <privilege>
+          <privilege-name>xdmp:eval</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:eval-in</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:http-delete</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:http-get</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:http-head</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:http-post</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:http-put</privilege-name>
         </privilege>
       </privileges>
     </role>
@@ -485,10 +526,10 @@
     </user>
   </users>
   <amps xmlns="http://marklogic.com/xdmp/security">
-<!--
-  Sample amp. See the Understanding and Using Security Guide section 5.2 for
-  information about amps.
-  http://community.marklogic.com/pubs/5.0/books/security.pdf
+    <!--
+      Sample amp. See the Understanding and Using Security Guide section 5.2 for
+      information about amps.
+      http://community.marklogic.com/pubs/5.0/books/security.pdf
     <amp>
       <namespace>http://marklogic.com/roxy</namespace>
       <local-name>sample</local-name>
@@ -496,7 +537,88 @@
       <db-name>${app-modules-db}</db-name>
       <role-name>a-privileged-role</role-name>
     </amp>
--->
+    -->
+    <!-- This group of amps allows the app-user to run the unit tests. If you
+         aren't using the Unit Test framework, or if you run them as admin, you
+         can safely delete these.
+    -->
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>list-from-database</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>get-modules-file</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>load-test-file</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>remove-modules</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>remove-modules-directories</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test-helper</namespace>
+      <local-name>http-get</local-name>
+      <doc-uri>/test/test-helper.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test/framework</namespace>
+      <local-name>http-head</local-name>
+      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test/framework</namespace>
+      <local-name>http-delete</local-name>
+      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test/framework</namespace>
+      <local-name>http-post</local-name>
+      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test/framework</namespace>
+      <local-name>http-put</local-name>
+      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
+    <amp>
+      <namespace>http://marklogic.com/roxy/test/framework</namespace>
+      <local-name>create-delete-target</local-name>
+      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
+      <db-name>${app-modules-db}</db-name>
+      <role-name>${app-role}-unit-test</role-name>
+    </amp>
   </amps>
   <privileges xmlns="http://marklogic.com/xdmp/security">
 <!--

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -488,7 +488,21 @@
     <role>
       <role-name>${app-role}-unit-test</role-name>
       <description>A role for unit testing the ${app-name} application</description>
+      <role-names>
+        <role-name>${app-role}</role-name>
+      </role-names>
       <privileges>
+        <!-- START: privileges needed for unit testing while running on filesystem -->
+        <privilege>
+          <privilege-name>xdmp:document-get</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:filesystem-directory</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:save</privilege-name>
+        </privilege>
+        <!-- END: privileges needed for unit testing while running on filesystem -->
         <privilege>
           <privilege-name>xdmp:eval</privilege-name>
         </privilege>
@@ -524,6 +538,7 @@
       <permissions/>
       <collections/>
     </user>
+    @ml.test-user-xml
   </users>
   <amps xmlns="http://marklogic.com/xdmp/security">
     <!--
@@ -538,87 +553,6 @@
       <role-name>a-privileged-role</role-name>
     </amp>
     -->
-    <!-- This group of amps allows the app-user to run the unit tests. If you
-         aren't using the Unit Test framework, or if you run them as admin, you
-         can safely delete these.
-    -->
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>list-from-database</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>get-modules-file</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>load-test-file</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>remove-modules</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>remove-modules-directories</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test-helper</namespace>
-      <local-name>http-get</local-name>
-      <doc-uri>/test/test-helper.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test/framework</namespace>
-      <local-name>http-head</local-name>
-      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test/framework</namespace>
-      <local-name>http-delete</local-name>
-      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test/framework</namespace>
-      <local-name>http-post</local-name>
-      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test/framework</namespace>
-      <local-name>http-put</local-name>
-      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
-    <amp>
-      <namespace>http://marklogic.com/roxy/test/framework</namespace>
-      <local-name>create-delete-target</local-name>
-      <doc-uri>/test/suites/Framework Tests/lib/framework-lib.xqy</doc-uri>
-      <db-name>${app-modules-db}</db-name>
-      <role-name>${app-role}-unit-test</role-name>
-    </amp>
   </amps>
   <privileges xmlns="http://marklogic.com/xdmp/security">
 <!--

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -458,9 +458,6 @@
       </collections>
       <privileges>
         <privilege>
-          <privilege-name>any-uri</privilege-name>
-        </privilege>
-        <privilege>
           <privilege-name>rest-reader</privilege-name>
         </privilege>
         <privilege>
@@ -503,6 +500,9 @@
           <privilege-name>xdmp:save</privilege-name>
         </privilege>
         <!-- END: privileges needed for unit testing while running on filesystem -->
+        <privilege>
+          <privilege-name>any-uri</privilege-name>
+        </privilege>
         <privilege>
           <privilege-name>xdmp:eval</privilege-name>
         </privilege>

--- a/src/app/config/config.xqy
+++ b/src/app/config/config.xqy
@@ -60,6 +60,18 @@ declare variable $c:ROXY-ROUTES :=
 
 (:
  : ***********************************************
+ : What is the default language of the controllers defined in the <request>
+ : sjs - Serverside JavaScript
+ : xqy - XQuery (default)
+ :
+ : Override this setting in the build.properties with the "controller-ext" key value pair.
+ :
+ : ***********************************************
+ :)
+declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[1];
+
+(:
+ : ***********************************************
  : A decent place to put your appservices search config
  : and various other search options.
  : The examples below are used by the appbuilder style

--- a/src/roxy/config/defaults.xqy
+++ b/src/roxy/config/defaults.xqy
@@ -89,6 +89,11 @@ declare variable $ROXY-ROUTES :=
     </routes>;
 
 (:
+ : Default controller language
+ :)
+declare variable $CTRL-EXT := "xqy";
+
+(:
  : ***********************************************
  : A decent place to put your appservices search config
  : and various other search options

--- a/src/roxy/router.xqy
+++ b/src/roxy/router.xqy
@@ -27,7 +27,14 @@ import module namespace u = "http://marklogic.com/roxy/util" at "/roxy/lib/util.
 declare option xdmp:mapping "false";
 
 declare variable $controller as xs:QName := req:get("controller", "type=xs:QName");
-declare variable $controller-path as xs:string := fn:concat("/app/controllers/", $controller, ".xqy");
+declare variable $language as xs:string := req:get("language", $config:CTRL-EXT, "type=xs:string");
+declare variable $controller-path as xs:string := fn:concat("/app/controllers/", $controller, ".", $language);
+declare variable $controller-ns as xs:string :=
+  if ($language eq "xqy") then
+    fn:concat("http://marklogic.com/roxy/controller/", $controller)
+  else
+    "";
+
 declare variable $func as xs:string := req:get("func", "main", "type=xs:string");
 declare variable $default-format :=
   (
@@ -50,7 +57,7 @@ declare function router:route()
   let $data :=
     xdmp:apply(
       xdmp:function(
-        fn:QName(fn:concat("http://marklogic.com/roxy/controller/", $controller), $func),
+        fn:QName($controller-ns, $func),
         $controller-path))
 
   (: Roxy options :)

--- a/src/test/default.xqy
+++ b/src/test/default.xqy
@@ -103,8 +103,10 @@ declare function t:run-suite($suite as xs:string, $tests as xs:string*, $run-sui
         }
       }
       catch($ex) {
-        if ($ex/error:code = "XDMP-MODNOTFOUND" and
-          fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suite-setup.xqy$")) then
+        if (($ex/error:code = "XDMP-MODNOTFOUND" and
+             fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suite-setup.xqy$")) or
+            ($ex/error:code = "SVC-FILOPN" and
+             fn:matches($ex/error:expr, "suite-setup.xqy"))) then
           try {
             xdmp:invoke(fn:concat("suites/", $suite, "/suiteSetup.sjs")),
             element t:test {
@@ -116,8 +118,10 @@ declare function t:run-suite($suite as xs:string, $tests as xs:string*, $run-sui
             }
           }
           catch ($ex) {
-            if ($ex/error:code = "XDMP-MODNOTFOUND" and
-              fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suiteSetup.sjs$")) then
+            if (($ex/error:code = "XDMP-MODNOTFOUND" and
+                 fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suiteSetup.sjs$")) or
+                ($ex/error:code = "SVC-FILOPN" and
+                 fn:matches($ex/error:expr, "suiteSetup.sjs"))) then
               ()
             else
               element t:test {
@@ -164,8 +168,10 @@ declare function t:run-suite($suite as xs:string, $tests as xs:string*, $run-sui
           }
         }
         catch($ex) {
-          if ($ex/error:code = "XDMP-MODNOTFOUND" and
-            fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suite-teardown.xqy$")) then
+          if (($ex/error:code = "XDMP-MODNOTFOUND" and
+               fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suite-teardown.xqy$")) or
+              ($ex/error:code = "SVC-FILOPN" and
+               fn:matches($ex/error:expr, "suite-teardown.xqy"))) then
             try {
               xdmp:invoke(fn:concat("suites/", $suite, "/suiteTeardown.sjs")),
               element t:test {
@@ -177,8 +183,10 @@ declare function t:run-suite($suite as xs:string, $tests as xs:string*, $run-sui
               }
             }
             catch($ex) {
-              if ($ex/error:code = "XDMP-MODNOTFOUND" and
-                fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suiteTeardown.sjs$")) then
+              if (($ex/error:code = "XDMP-MODNOTFOUND" and
+                   fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/suiteTeardown.sjs$")) or
+                  ($ex/error:code = "SVC-FILOPN" and
+                   fn:matches($ex/error:expr, "suiteTeardown.sjs"))) then
                 ()
               else
                 element t:test {
@@ -225,15 +233,19 @@ declare function t:run($suite as xs:string, $name as xs:string, $module, $run-te
       return ()
     }
     catch($ex) {
-      if ($ex/error:code = "XDMP-MODNOTFOUND" and
-        fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/setup.xqy$")) then
+      if (($ex/error:code = "XDMP-MODNOTFOUND" and
+           fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/setup.xqy$")) or
+          ($ex/error:code = "SVC-FILOPN" and
+           fn:matches($ex/error:expr, "setup.xqy"))) then
         try {
           let $_ := xdmp:invoke(fn:concat("suites/", $suite, "/setup.sjs"))
           return ()
         }
         catch($ex) {
-          if ($ex/error:code = "XDMP-MODNOTFOUND" and
-            fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/setup.sjs$")) then
+          if (($ex/error:code = "XDMP-MODNOTFOUND" and
+               fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/setup.sjs$")) or
+              ($ex/error:code = "SVC-FILOPN" and
+           fn:matches($ex/error:expr, "setup.sjs"))) then
             ()
           else
             element t:result {
@@ -272,14 +284,18 @@ declare function t:run($suite as xs:string, $name as xs:string, $module, $run-te
         xdmp:invoke(fn:concat("suites/", $suite, "/teardown.xqy"))
       }
       catch($ex) {
-        if ($ex/error:code = "XDMP-MODNOTFOUND" and
-          fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/teardown.xqy$")) then
+        if (($ex/error:code = "XDMP-MODNOTFOUND" and
+             fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/teardown.xqy$")) or
+            ($ex/error:code = "SVC-FILOPN" and
+             fn:matches($ex/error:expr, "teardown.xqy"))) then
           try {
             xdmp:invoke(fn:concat("suites/", $suite, "/teardown.sjs"))
           }
           catch($ex) {
-            if ($ex/error:code = "XDMP-MODNOTFOUND" and
-              fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/teardown.sjs$")) then
+            if (($ex/error:code = "XDMP-MODNOTFOUND" and
+                 fn:matches($ex/error:stack/error:frame[1]/error:uri/fn:string(), "/teardown.sjs$")) or
+                ($ex/error:code = "SVC-FILOPN" and
+                 fn:matches($ex/error:expr, "teardown.sjs"))) then
               ()
             else
               element t:result {

--- a/src/test/default.xqy
+++ b/src/test/default.xqy
@@ -34,24 +34,6 @@ declare variable $FS-PATH  as xs:string :=
 
 declare option xdmp:mapping "false";
 
-declare function t:list-from-database(
-  $database as xs:unsignedLong,
-  $root as xs:string,
-  $suite as xs:string?)
-as xs:string*
-{
-  xdmp:eval(
-    'xquery version "1.0-ml";
-    declare variable $PATH as xs:string external;
-    try { cts:uris((), (), cts:directory-query($PATH, "infinity")) }
-    catch ($ex) {
-      if ($ex/error:code ne "XDMP-URILXCNNOTFOUND") then xdmp:rethrow()
-      else xdmp:directory($PATH, "infinity")/xdmp:node-uri(.) }',
-    (xs:QName('PATH'),
-      fn:concat($root, 'test/suites/', ($suite, '')[1])),
-    <options xmlns="xdmp:eval"><database>{$database}</database></options>)
-};
-
 (:~
  : Returns a list of the available tests. This list is magically computed based on the modules
  :)
@@ -66,7 +48,7 @@ declare function t:list() {
         if ($db-id = 0) then
           xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites"))/dir:entry[dir:type = "directory" and fn:not(dir:filename = $suite-ignore-list)]/dir:filename
         else
-          let $uris := t:list-from-database($db-id, $root, ())
+          let $uris := helper:list-from-database($db-id, $root, ())
           return
             fn:distinct-values(
               for $uri in $uris
@@ -79,7 +61,7 @@ declare function t:list() {
         if ($db-id = 0) then
           xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xqy") or fn:ends-with(., ".sjs")]
         else
-          let $uris := t:list-from-database(
+          let $uris := helper:list-from-database(
             $db-id, $root, fn:concat($suite, '/'))
           return
             fn:distinct-values(

--- a/src/test/suites/Framework Tests/lib/framework-lib.xqy
+++ b/src/test/suites/Framework Tests/lib/framework-lib.xqy
@@ -1,0 +1,37 @@
+xquery version "1.0-ml";
+
+module namespace frm = "http://marklogic.com/roxy/test/framework";
+
+declare option xdmp:mapping "false";
+
+(: Wrapper so that we can have an amp, allowing the default user to run this
+ : test without getting extra privileges.
+ :)
+declare function frm:http-head($url, $options)
+{
+  xdmp:http-head($url, $options)
+};
+
+(: Wrapper so that we can have an amp, allowing the default user to run this
+ : test without getting extra privileges.
+ :)
+declare function frm:http-delete($url, $options)
+{
+  xdmp:http-delete($url, $options)
+};
+
+(: Wrapper so that we can have an amp, allowing the default user to run this
+ : test without getting extra privileges.
+ :)
+declare function frm:http-post($url, $options)
+{
+  xdmp:http-post($url, $options)
+};
+
+(: Wrapper so that we can have an amp, allowing the default user to run this
+ : test without getting extra privileges.
+ :)
+declare function frm:http-put($url, $options)
+{
+  xdmp:http-put($url, $options)
+};

--- a/src/test/suites/Framework Tests/routing.xqy
+++ b/src/test/suites/Framework Tests/routing.xqy
@@ -31,9 +31,17 @@ declare variable $options-non-xml :=
     </authentication>
   </options>;
 
+(:
+ : Each of the URLs being tested here includes the language parameter, because
+ : the controllers can be implemented in either XQuery or SJS. The default is
+ : controlled by a property. In order to avoid false negatives, these tests
+ : make that choice explicit.
+ :)
+declare variable $LANG-XQY := "language=xqy";
+declare variable $LANG-SJS := "language=sjs";
 
 (: Verify that /tester will call tester:main and return the html view :)
-let $response := xdmp:http-get(test:easy-url("/tester"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -42,7 +50,7 @@ return
 ),
 
 (: Verify that the .html will return the html view :)
-let $response := xdmp:http-get(test:easy-url("/tester.html"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester.html?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -51,7 +59,7 @@ return
 ),
 
 (: Verify that the .xml will return the xml view :)
-let $response := xdmp:http-get(test:easy-url("/tester.xml"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester.xml?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -59,7 +67,7 @@ return
 ),
 
 (: JSON view is not defined. Should throw a 500 error with handy error message :)
-let $response := xdmp:http-get(test:easy-url("/tester.json"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester.json?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -67,7 +75,7 @@ return
 ),
 
 (: verify that a handy error message is displayed when a layout is missing. :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-layout"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/missing-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -75,7 +83,7 @@ return
 ),
 
 (: verify that a handy error message is displayed when a view is missing. :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-view"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/missing-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -83,7 +91,7 @@ return
 ),
 
 (: verify that turning off the layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-layout"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/no-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -92,7 +100,7 @@ return
 ),
 
 (: verify that turning off the view works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-view"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/no-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -101,7 +109,7 @@ return
 ),
 
 (: verify that turning off the view and layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-view-or-layout"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/no-view-or-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -109,7 +117,7 @@ return
 ),
 
 (: verify that specifying a different view works :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/different-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -118,7 +126,7 @@ return
 ),
 
 (: verify that specifying a different layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-layout"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/different-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -127,7 +135,7 @@ return
 ),
 
 (: verify that specifying a different view for only xml works - first get html :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -136,7 +144,7 @@ return
 ),
 
 (: verify that specifying a different view for only xml works - now get xml :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only.xml"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only.xml?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -144,7 +152,7 @@ return
 ),
 
 (: verify that returning the input from the view doesn't break anything :)
-let $response := xdmp:http-get(test:easy-url("/tester/view-that-returns-the-input"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/view-that-returns-the-input?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -153,7 +161,7 @@ return
 ),
 
 (: verify that a missing variable returns a handy error message :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-variable"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/missing-variable?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -161,7 +169,7 @@ return
 ),
 
 (: verify that a bad import propagates the correct error :)
-let $response := xdmp:http-get(test:easy-url("/tester/layout-with-bad-import"), $options-non-xml)
+let $response := xdmp:http-get(test:easy-url("/tester/layout-with-bad-import?" || $LANG-XQY), $options-non-xml)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -169,7 +177,7 @@ return
 ),
 
 (: verify that a bad import propagates the correct error :)
-let $response := xdmp:http-get(test:easy-url("/tester/view-with-bad-import"), $options-non-xml)
+let $response := xdmp:http-get(test:easy-url("/tester/view-with-bad-import?" || $LANG-XQY), $options-non-xml)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -198,52 +206,87 @@ return
   test:assert-equal(200, fn:data($response[1]/*:code))
 ),
 
-(: verify that a non-existent route returns 404 :)
+(: verify that a non-existent route returns 404
+ : Since it's not a real controller, doesn't matter what language we ask for
+ :)
 let $response := xdmp:http-get(test:easy-url("/not-real"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
 ),
 
-(: verify that a non-existent route returns 404 :)
+(: verify that a non-existent route returns 404
+ : Since it's not a real controller, doesn't matter what language we ask for
+ :)
 let $response := xdmp:http-get(test:easy-url("/not-real.xml"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
 ),
 
-(: verify that a non-existent route returns 404 :)
+(: verify that a non-existent route returns 404
+ : Since it's not a real controller, doesn't matter what language we ask for
+ :)
 let $response := xdmp:http-get(test:easy-url("/not-real/at-all"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
 ),
 
-let $response := xdmp:http-get(test:easy-url("/tester/update"), $options)
+let $response := xdmp:http-get(test:easy-url("/tester/update?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
   test:assert-equal("XDMP-UPDATEFUNCTIONFROMQUERY", fn:string($response[2]//*:code))
 ),
 
-let $response := xdmp:http-head(test:easy-url("/tester/update"), $options)
+let $response := xdmp:http-head(test:easy-url("/tester/update?"  || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code))
   (: A HEAD request doesn't get the body, so we can't check the detailed message :)
 ),
 
-let $response := xdmp:http-delete(test:easy-url("/tester/delete?uri=/delete-me.xml"), $options-non-xml)
-return 
-  test:assert-equal(200, fn:data($response[1]/*:code)),
-
-let $response := xdmp:http-post(test:easy-url("/tester/update"), $options-non-xml)
+let $response := xdmp:http-delete(test:easy-url("/tester/delete?uri=/delete-me.xml&amp;"  || $LANG-XQY), $options-non-xml)
 return
   test:assert-equal(200, fn:data($response[1]/*:code)),
 
-let $response := xdmp:http-put(test:easy-url("/tester/update2"), $options-non-xml)
+let $response := xdmp:http-post(test:easy-url("/tester/update?"  || $LANG-XQY), $options-non-xml)
 return
-  test:assert-equal(200, fn:data($response[1]/*:code))
+  test:assert-equal(200, fn:data($response[1]/*:code)),
+
+let $response := xdmp:http-put(test:easy-url("/tester/update2?"  || $LANG-XQY), $options-non-xml)
+return
+  test:assert-equal(200, fn:data($response[1]/*:code)),
+
+(: test the SJS controller's default function :)
+let $response := xdmp:http-get(test:easy-url("/tester?"  || $LANG-SJS), $options)
+return
+(
+  test:assert-equal(200, fn:data($response[1]/*:code)),
+  test:assert-equal("main", fn:string($response[2]//html:title)),
+  test:assert-equal("test message: main", fn:string($response[2]//html:div[@id="message"]))
+),
+
+(: test the SJS controller's default function :)
+let $response := xdmp:http-get(test:easy-url("/tester/print?" || $LANG-SJS), $options)
+return
+(
+  test:assert-equal(200, fn:data($response[1]/*:code)),
+  test:assert-equal("this is print", fn:string($response[2]/div/fn:string()))
+),
+
+(: both the XQuery and SJS controllers have a main function. Test whichever is
+ : configured.
+ :)
+let $response := xdmp:http-get(test:easy-url("/tester"), $options)
+return
+(
+  test:assert-equal(200, fn:data($response[1]/*:code)),
+  test:assert-equal("main", fn:string($response[2]//html:title)),
+  test:assert-equal("test message: main", fn:string($response[2]//html:div[@id="message"]))
+)
+
 
 ;
 

--- a/src/test/suites/Framework Tests/routing.xqy
+++ b/src/test/suites/Framework Tests/routing.xqy
@@ -20,16 +20,16 @@ declare variable $options :=
   <options xmlns="xdmp:http">
     <format xmlns="xdmp:document-get">xml</format>
     <authentication method="digest">
-      <username>{$c:APP-USER}</username>
-      <password>{$c:APP-USER-PASSWORD}</password>
+      <username>{$c:TEST-USER}</username>
+      <password>{$c:TEST-USER-PASSWORD}</password>
     </authentication>
   </options>;
 
 declare variable $options-non-xml :=
   <options xmlns="xdmp:http">
     <authentication method="digest">
-      <username>{$c:APP-USER}</username>
-      <password>{$c:APP-USER-PASSWORD}</password>
+      <username>{$c:TEST-USER}</username>
+      <password>{$c:TEST-USER-PASSWORD}</password>
     </authentication>
   </options>;
 
@@ -41,6 +41,8 @@ declare variable $options-non-xml :=
  :)
 declare variable $LANG-XQY := "language=xqy";
 declare variable $LANG-SJS := "language=sjs";
+
+xdmp:log("options: " || xdmp:quote($options)),
 
 (: Verify that /tester will call tester:main and return the html view :)
 let $response := test:http-get(test:easy-url("/tester?" || $LANG-XQY), $options)

--- a/src/test/suites/Framework Tests/routing.xqy
+++ b/src/test/suites/Framework Tests/routing.xqy
@@ -12,22 +12,24 @@ import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/t
 
 import module namespace c = "http://marklogic.com/roxy/test-config" at "/test/test-config.xqy";
 
+import module namespace frm = "http://marklogic.com/roxy/test/framework" at "lib/framework-lib.xqy";
+
 declare namespace html = "http://www.w3.org/1999/xhtml";
 
 declare variable $options :=
   <options xmlns="xdmp:http">
     <format xmlns="xdmp:document-get">xml</format>
     <authentication method="digest">
-      <username>{$c:USER}</username>
-      <password>{$c:PASSWORD}</password>
+      <username>{$c:APP-USER}</username>
+      <password>{$c:APP-USER-PASSWORD}</password>
     </authentication>
   </options>;
 
 declare variable $options-non-xml :=
   <options xmlns="xdmp:http">
     <authentication method="digest">
-      <username>{$c:USER}</username>
-      <password>{$c:PASSWORD}</password>
+      <username>{$c:APP-USER}</username>
+      <password>{$c:APP-USER-PASSWORD}</password>
     </authentication>
   </options>;
 
@@ -41,7 +43,7 @@ declare variable $LANG-XQY := "language=xqy";
 declare variable $LANG-SJS := "language=sjs";
 
 (: Verify that /tester will call tester:main and return the html view :)
-let $response := xdmp:http-get(test:easy-url("/tester?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -50,7 +52,7 @@ return
 ),
 
 (: Verify that the .html will return the html view :)
-let $response := xdmp:http-get(test:easy-url("/tester.html?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester.html?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -59,7 +61,7 @@ return
 ),
 
 (: Verify that the .xml will return the xml view :)
-let $response := xdmp:http-get(test:easy-url("/tester.xml?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester.xml?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -67,7 +69,7 @@ return
 ),
 
 (: JSON view is not defined. Should throw a 500 error with handy error message :)
-let $response := xdmp:http-get(test:easy-url("/tester.json?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester.json?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -75,7 +77,7 @@ return
 ),
 
 (: verify that a handy error message is displayed when a layout is missing. :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-layout?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/missing-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -83,7 +85,7 @@ return
 ),
 
 (: verify that a handy error message is displayed when a view is missing. :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-view?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/missing-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -91,7 +93,7 @@ return
 ),
 
 (: verify that turning off the layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-layout?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/no-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -100,7 +102,7 @@ return
 ),
 
 (: verify that turning off the view works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-view?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/no-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -109,7 +111,7 @@ return
 ),
 
 (: verify that turning off the view and layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/no-view-or-layout?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/no-view-or-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -117,7 +119,7 @@ return
 ),
 
 (: verify that specifying a different view works :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/different-view?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -126,7 +128,7 @@ return
 ),
 
 (: verify that specifying a different layout works :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-layout?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/different-layout?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -135,7 +137,7 @@ return
 ),
 
 (: verify that specifying a different view for only xml works - first get html :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/different-view-xml-only?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -144,7 +146,7 @@ return
 ),
 
 (: verify that specifying a different view for only xml works - now get xml :)
-let $response := xdmp:http-get(test:easy-url("/tester/different-view-xml-only.xml?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/different-view-xml-only.xml?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -152,7 +154,7 @@ return
 ),
 
 (: verify that returning the input from the view doesn't break anything :)
-let $response := xdmp:http-get(test:easy-url("/tester/view-that-returns-the-input?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/view-that-returns-the-input?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -161,7 +163,7 @@ return
 ),
 
 (: verify that a missing variable returns a handy error message :)
-let $response := xdmp:http-get(test:easy-url("/tester/missing-variable?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/missing-variable?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -169,7 +171,7 @@ return
 ),
 
 (: verify that a bad import propagates the correct error :)
-let $response := xdmp:http-get(test:easy-url("/tester/layout-with-bad-import?" || $LANG-XQY), $options-non-xml)
+let $response := test:http-get(test:easy-url("/tester/layout-with-bad-import?" || $LANG-XQY), $options-non-xml)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -177,7 +179,7 @@ return
 ),
 
 (: verify that a bad import propagates the correct error :)
-let $response := xdmp:http-get(test:easy-url("/tester/view-with-bad-import?" || $LANG-XQY), $options-non-xml)
+let $response := test:http-get(test:easy-url("/tester/view-with-bad-import?" || $LANG-XQY), $options-non-xml)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
@@ -186,21 +188,21 @@ return
 
 
 (: verify that public resources are accessible :)
-let $response := xdmp:http-get(test:easy-url("/css/app.less"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/css/app.less"), $options-non-xml)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code))
 ),
 
 (: verify that public resources are accessible :)
-let $response := xdmp:http-get(test:easy-url("/images/ml-logo.gif"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/images/ml-logo.gif"), $options-non-xml)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code))
 ),
 
 (: verify that public resources are accessible :)
-let $response := xdmp:http-get(test:easy-url("/js/app.js"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/js/app.js"), $options-non-xml)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code))
@@ -209,7 +211,7 @@ return
 (: verify that a non-existent route returns 404
  : Since it's not a real controller, doesn't matter what language we ask for
  :)
-let $response := xdmp:http-get(test:easy-url("/not-real"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/not-real"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
@@ -218,7 +220,7 @@ return
 (: verify that a non-existent route returns 404
  : Since it's not a real controller, doesn't matter what language we ask for
  :)
-let $response := xdmp:http-get(test:easy-url("/not-real.xml"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/not-real.xml"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
@@ -227,40 +229,40 @@ return
 (: verify that a non-existent route returns 404
  : Since it's not a real controller, doesn't matter what language we ask for
  :)
-let $response := xdmp:http-get(test:easy-url("/not-real/at-all"), $options-non-xml)
+let $response := test:http-get(test:easy-url("/not-real/at-all"), $options-non-xml)
 return
 (
   test:assert-equal(404, fn:data($response[1]/*:code))
 ),
 
-let $response := xdmp:http-get(test:easy-url("/tester/update?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/tester/update?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code)),
   test:assert-equal("XDMP-UPDATEFUNCTIONFROMQUERY", fn:string($response[2]//*:code))
 ),
 
-let $response := xdmp:http-head(test:easy-url("/tester/update?"  || $LANG-XQY), $options)
+let $response := frm:http-head(test:easy-url("/tester/update?"  || $LANG-XQY), $options)
 return
 (
   test:assert-equal(500, fn:data($response[1]/*:code))
   (: A HEAD request doesn't get the body, so we can't check the detailed message :)
 ),
 
-let $response := xdmp:http-delete(test:easy-url("/tester/delete?uri=/delete-me.xml&amp;"  || $LANG-XQY), $options-non-xml)
+let $response := frm:http-delete(test:easy-url("/tester/delete?uri=/delete-me.xml&amp;"  || $LANG-XQY), $options-non-xml)
 return
   test:assert-equal(200, fn:data($response[1]/*:code)),
 
-let $response := xdmp:http-post(test:easy-url("/tester/update?"  || $LANG-XQY), $options-non-xml)
+let $response := frm:http-post(test:easy-url("/tester/update?"  || $LANG-XQY), $options-non-xml)
 return
   test:assert-equal(200, fn:data($response[1]/*:code)),
 
-let $response := xdmp:http-put(test:easy-url("/tester/update2?"  || $LANG-XQY), $options-non-xml)
+let $response := frm:http-put(test:easy-url("/tester/update2?"  || $LANG-XQY), $options-non-xml)
 return
   test:assert-equal(200, fn:data($response[1]/*:code)),
 
 (: test the SJS controller's default function :)
-let $response := xdmp:http-get(test:easy-url("/tester?"  || $LANG-SJS), $options)
+let $response := test:http-get(test:easy-url("/tester?"  || $LANG-SJS), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -269,7 +271,7 @@ return
 ),
 
 (: test the SJS controller's default function :)
-let $response := xdmp:http-get(test:easy-url("/tester/print?" || $LANG-SJS), $options)
+let $response := test:http-get(test:easy-url("/tester/print?" || $LANG-SJS), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),
@@ -279,7 +281,7 @@ return
 (: both the XQuery and SJS controllers have a main function. Test whichever is
  : configured.
  :)
-let $response := xdmp:http-get(test:easy-url("/tester"), $options)
+let $response := test:http-get(test:easy-url("/tester"), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),

--- a/src/test/suites/Framework Tests/site-index.xqy
+++ b/src/test/suites/Framework Tests/site-index.xqy
@@ -4,6 +4,14 @@ import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/t
 
 import module namespace c = "http://marklogic.com/roxy/test-config" at "/test/test-config.xqy";
 
+(:
+ : Each of the URLs being tested here includes the language parameter, because
+ : the controllers can be implemented in either XQuery or SJS. The default is
+ : controlled by a property. In order to avoid false negatives, these tests
+ : make that choice explicit.
+ :)
+declare variable $LANG-XQY := "language=xqy";
+
 let $options :=
   <options xmlns="xdmp:http">
     <format xmlns="xdmp:document-get">xml</format>
@@ -12,7 +20,7 @@ let $options :=
       <password>{$c:PASSWORD}</password>
     </authentication>
   </options>
-let $response := xdmp:http-get(test:easy-url("/"), $options)
+let $response := xdmp:http-get(test:easy-url("/?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),

--- a/src/test/suites/Framework Tests/site-index.xqy
+++ b/src/test/suites/Framework Tests/site-index.xqy
@@ -20,7 +20,7 @@ let $options :=
       <password>{$c:PASSWORD}</password>
     </authentication>
   </options>
-let $response := xdmp:http-get(test:easy-url("/?" || $LANG-XQY), $options)
+let $response := test:http-get(test:easy-url("/?" || $LANG-XQY), $options)
 return
 (
   test:assert-equal(200, fn:data($response[1]/*:code)),

--- a/src/test/suites/Framework Tests/suite-setup.xqy
+++ b/src/test/suites/Framework Tests/suite-setup.xqy
@@ -2,6 +2,15 @@ xquery version "1.0-ml";
 
 import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
+(: These tests require the modules database, because they will make HTTP
+ : requests using credentials from test-config.xqy. Those credentials will only
+ : be available if property substitution happens, which only works when using a
+ : modules database.
+ :)
+if (xdmp:modules-database() eq 0) then
+  test:fail("You must run this test from a modules database.")
+else (),
+
 (: create a test controller and views :)
 test:load-test-file("tester.xqy", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/controllers/tester.xqy")),
 test:load-test-file("tester.sjs", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/controllers/tester.sjs")),

--- a/src/test/suites/Framework Tests/suite-setup.xqy
+++ b/src/test/suites/Framework Tests/suite-setup.xqy
@@ -4,6 +4,7 @@ import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/t
 
 (: create a test controller and views :)
 test:load-test-file("tester.xqy", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/controllers/tester.xqy")),
+test:load-test-file("tester.sjs", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/controllers/tester.sjs")),
 test:load-test-file("missing-map.xqy", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/controllers/missing-map.xqy")),
 test:load-test-file("different-layout-view.html.xqy", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/views/tester/different-layout.html.xqy")),
 test:load-test-file("different-view-xml-only.html.xqy", xdmp:modules-database(), fn:concat(xdmp:modules-root(), "app/views/tester/different-view-xml-only.html.xqy")),

--- a/src/test/suites/Framework Tests/suite-teardown.xqy
+++ b/src/test/suites/Framework Tests/suite-teardown.xqy
@@ -1,17 +1,15 @@
 xquery version "1.0-ml";
 
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
 (: remove the test controller and views :)
-if (xdmp:modules-database() ne 0) then
-  xdmp:eval('
-    xquery version "1.0-ml";
-    xdmp:directory-delete("/app/views/tester/"),
-    xdmp:document-delete("/app/views/layouts/different-layout.html.xqy"),
-    xdmp:document-delete("/app/controllers/tester.xqy")',
-    (),
-    <options xmlns="xdmp:eval">
-      <database>{xdmp:modules-database()}</database>
-    </options>)
-else (),
+test:remove-modules((
+  "/app/views/layouts/different-layout.html.xqy",
+  "/app/controllers/tester.xqy"
+)),
+test:remove-modules-directories((
+  "/app/views/tester/"
+)),
 
 try
 {

--- a/src/test/suites/Framework Tests/test-data/tester.sjs
+++ b/src/test/suites/Framework Tests/test-data/tester.sjs
@@ -1,0 +1,14 @@
+var req = require("/roxy/lib/request.xqy");
+
+module.exports = {
+
+  main : function () {
+    return '<html xmlns="http://www.w3.org/1999/xhtml">' +
+      '  <title>main</title>' +
+      '  <div id="message">test message: main</div>' +
+      '</html>';
+  },
+  print : function () {
+    return "<div>this is print</div>";
+  }
+};

--- a/src/test/suites/request-lib/suite-teardown.xqy
+++ b/src/test/suites/request-lib/suite-teardown.xqy
@@ -1,12 +1,6 @@
 xquery version "1.0-ml";
 
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
 (: remove the test controller :)
-if (xdmp:modules-database() ne 0) then
-  xdmp:eval('
-    xquery version "1.0-ml";
-    xdmp:document-delete("/app/controllers/test-request.xqy")',
-    (),
-    <options xmlns="xdmp:eval">
-      <database>{xdmp:modules-database()}</database>
-    </options>)
-else ()
+test:remove-modules(("/app/controllers/test-request.xqy"))

--- a/src/test/suites/transactional/README.md
+++ b/src/test/suites/transactional/README.md
@@ -1,0 +1,2 @@
+The tests in this suite exercise the Roxy Unit Test framework's method of 
+doing multi-transaction tests. 

--- a/src/test/suites/transactional/setup.xqy
+++ b/src/test/suites/transactional/setup.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+xdmp:document-insert("/test1.xml",
+  <doc>
+    <meta>
+      <tags/>
+    </meta>
+  </doc>
+)

--- a/src/test/suites/transactional/tag.xqy
+++ b/src/test/suites/transactional/tag.xqy
@@ -1,0 +1,18 @@
+xquery version "1.0-ml";
+
+try {
+  xdmp:node-insert-child(
+    fn:doc('/test1.xml')/doc/meta/tags,
+    <tag>tag1</tag>
+  )
+} catch ($e) {
+  xdmp:log("tag:add() threw an exception: " || xdmp:quote($e))
+}
+
+;
+
+xquery version "1.0-ml";
+
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+test:assert-exists(fn:doc("/test1.xml")/doc/meta/tags/tag[./text() = "tag1"])

--- a/src/test/suites/transactional/teardown.xqy
+++ b/src/test/suites/transactional/teardown.xqy
@@ -1,0 +1,3 @@
+xquery version "1.0-ml";
+
+xdmp:document-delete('/test1.xml')

--- a/src/test/suites/transactional/transactional.xqy
+++ b/src/test/suites/transactional/transactional.xqy
@@ -1,0 +1,43 @@
+(: setup :)
+
+xquery version "1.0-ml";
+
+xdmp:document-insert("/test2.xml",
+  <doc>
+    <meta>
+      <tags/>
+    </meta>
+  </doc>)
+
+;
+
+(: test :)
+
+xquery version "1.0-ml";
+
+xdmp:node-insert-child(
+  fn:doc('/test2.xml')/doc/meta/tags,
+  <tag>tag1</tag>
+)
+
+;
+
+(: verify :)
+
+xquery version "1.0-ml";
+
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+try {
+  test:assert-exists(fn:doc("/test2.xml")/doc/meta/tags/tag[./text() = "tag1"])
+} catch ($e) {
+  if (fn:matches($e/error:name, "ASSERT-.*-FAILED")) then
+    xdmp:rethrow()
+  else
+    xdmp:log("tag:add() verification threw an exception: " || xdmp:quote($e))
+}
+
+;
+
+(: teardown :)
+xdmp:document-delete("/test2.xml")

--- a/src/test/test-config.xqy
+++ b/src/test/test-config.xqy
@@ -21,5 +21,9 @@ module namespace c = "http://marklogic.com/roxy/test-config";
 declare variable $c:USER := "@ml.user";
 declare variable $c:PASSWORD := "@ml.password";
 
-declare variable $c:APP-USER as xs:string := ("@ml.default-user", $c:USER)[1];
-declare variable $c:APP-USER-PASSWORD as xs:string := ("@ml.appuser-password", $c:PASSWORD)[1];
+declare variable $c:TEST-USER as xs:string :=
+  if (fn:matches("@ml.test-user", "@")) then $c:USER
+  else "@ml.test-user";
+declare variable $c:TEST-USER-PASSWORD as xs:string :=
+  if (fn:matches("@ml.test-user-password", "@")) then $c:PASSWORD
+  else "@ml.test-user-password";

--- a/src/test/test-config.xqy
+++ b/src/test/test-config.xqy
@@ -20,3 +20,6 @@ module namespace c = "http://marklogic.com/roxy/test-config";
 (: configured at deploy time by Roxy deployer :)
 declare variable $c:USER := "@ml.user";
 declare variable $c:PASSWORD := "@ml.password";
+
+declare variable $c:APP-USER as xs:string := ("@ml.default-user", $c:USER)[1];
+declare variable $c:APP-USER-PASSWORD as xs:string := ("@ml.appuser-password", $c:PASSWORD)[1];

--- a/src/test/test-helper.xqy
+++ b/src/test/test-helper.xqy
@@ -460,3 +460,57 @@ declare function helper:log($items as item()*)
   let $_ := fn:trace($items, "UNIT-TEST")
   return ()
 };
+
+declare function helper:list-from-database(
+  $database as xs:unsignedLong,
+  $root as xs:string,
+  $suite as xs:string?)
+as xs:string*
+{
+  xdmp:eval(
+    'xquery version "1.0-ml";
+    declare variable $PATH as xs:string external;
+    try { cts:uris((), (), cts:directory-query($PATH, "infinity")) }
+    catch ($ex) {
+      if ($ex/error:code ne "XDMP-URILXCNNOTFOUND") then xdmp:rethrow()
+      else xdmp:directory($PATH, "infinity")/xdmp:node-uri(.) }',
+    (xs:QName('PATH'),
+      fn:concat($root, 'test/suites/', ($suite, '')[1])),
+    <options xmlns="xdmp:eval"><database>{$database}</database></options>)
+};
+
+(:
+ : Use this function to clean up after tests that put stuff in the modules database.
+ :)
+declare function helper:remove-modules($uris as xs:string*)
+{
+  if (xdmp:modules-database() ne 0) then
+    xdmp:eval('
+      xquery version "1.0-ml";
+      declare variable $uris external;
+
+      $uris ! xdmp:document-delete(.)',
+      map:new((map:entry("uris", $uris))),
+      <options xmlns="xdmp:eval">
+        <database>{xdmp:modules-database()}</database>
+      </options>)
+  else ()
+};
+
+(:
+ : Use this function to clean up after tests that put stuff in the modules database.
+ :)
+declare function helper:remove-modules-directories($dirs as xs:string*)
+{
+  if (xdmp:modules-database() ne 0) then
+    xdmp:eval('
+      xquery version "1.0-ml";
+      declare variable $dirs external;
+
+      $dirs ! xdmp:directory-delete(.)',
+      map:new((map:entry("dirs", $dirs))),
+      <options xmlns="xdmp:eval">
+        <database>{xdmp:modules-database()}</database>
+      </options>)
+  else ()
+};


### PR DESCRIPTION
This PR makes unit tests work out of the box with the default user (ie, no longer requiring admin for tests to work). 

Question for reviewers: any concerns with the privileges that I've granted to the default user? 

- any-uri
- rest-reader
- xdmp:get-server-field
- xdmp:set-server-field

Three of those are required for Roxy's rewriter to work (see src/roxy/rewriter-lib.xqy rewrite-rules(); `eput:get-rest-options` requires rest-reader). 

The amps should be safe, in that the code they refer to isn't even deployed in production. 