### PR TITLE
#492 verify parameters during setup

### DIFF
--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2477,7 +2477,32 @@ declare function setup:add-geospatial-element-attribute-pair-indexes(
   admin:database-add-geospatial-element-attribute-pair-index(
     setup:remove-existing-geospatial-element-attribute-pair-indexes($admin-config, $database),
     $database,
-    $db-config/db:geospatial-element-attribute-pair-indexes/db:geospatial-element-attribute-pair-index)
+    for $index in $db-config/db:geospatial-element-attribute-pair-indexes/db:geospatial-element-attribute-pair-index
+    return
+      if (setup:at-least-version("6.0-0")) then
+        admin:database-geospatial-element-attribute-pair-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:latitude-namespace-uri,
+          $index/db:latitude-localname,
+          $index/db:longitude-namespace-uri,
+          $index/db:longitude-localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:invalid-values, "ignore")[1]
+        )
+      else
+        admin:database-geospatial-element-attribute-pair-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:latitude-namespace-uri,
+          $index/db:latitude-localname,
+          $index/db:longitude-namespace-uri,
+          $index/db:longitude-localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions
+        )
+  )
 };
 
 declare function setup:validate-geospatial-element-attribute-pair-indexes(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2423,8 +2423,29 @@ declare function setup:add-geospatial-element-indexes(
   $database as xs:unsignedLong,
   $db-config as element(db:database)) as element(configuration)
 {
-  admin:database-add-geospatial-element-index(setup:remove-existing-geospatial-element-indexes($admin-config, $database),
-    $database, $db-config/db:geospatial-element-indexes/db:geospatial-element-index)
+  admin:database-add-geospatial-element-index(
+    setup:remove-existing-geospatial-element-indexes($admin-config, $database),
+    $database,
+    for $index in $db-config/db:geospatial-element-indexes/db:geospatial-element-index
+    return
+      if (setup:at-least-version("6.0-0")) then
+        admin:database-geospatial-element-index(
+          $index/db:namespace-uri,
+          $index/db:localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:point-format, "point")[1],
+          ($index/db:invalid-values, "ignore")[1]
+        )
+      else
+        admin:database-geospatial-element-index(
+          $index/db:namespace-uri,
+          $index/db:localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:point-format, "point")[1]
+        )
+  )
 };
 
 declare function setup:validate-geospatial-element-indexes(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2355,24 +2355,8 @@ declare function setup:remove-existing-range-field-indexes(
   $admin-config as element(configuration),
   $database as xs:unsignedLong) as element(configuration)
 {
-  (: wrap in try catch because this function is new to 5.0 and will fail in older version of ML :)
-  try
-  {
-    xdmp:eval('
-      import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-      declare variable $admin-config external;
-      declare variable $database external;
-      admin:database-delete-range-field-index($admin-config, $database,
-        admin:database-get-range-field-indexes($admin-config, $database))',
-      (xs:QName("admin-config"), $admin-config,
-       xs:QName("database"), $database))
-  }
-  catch($ex)
-  {
-    if ($ex/error:code = "XDMP-UNDFUN") then $admin-config
-    else
-      xdmp:rethrow()
-  }
+  admin:database-delete-range-field-index($admin-config, $database,
+    admin:database-get-range-field-indexes($admin-config, $database))
 };
 
 declare function setup:add-range-field-indexes(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2677,29 +2677,16 @@ declare function setup:add-fragment-roots(
   $database as xs:unsignedLong,
   $db-config as element(db:database)) as element(configuration)
 {
-  setup:add-fragment-roots-R(
-    setup:remove-existing-fragment-roots($admin-config, $database),
+  admin:database-add-fragment-root(
+    $admin-config,
     $database,
-    $db-config/db:fragment-roots/db:fragment-root)
-};
-
-declare function setup:add-fragment-roots-R(
-  $admin-config as element(configuration),
-  $database as xs:unsignedLong,
-  $fragment-roots as element(db:fragment-root)*) as element(configuration)
-{
-  if ($fragment-roots) then
-    setup:add-fragment-roots-R(
-      admin:database-add-fragment-root(
-        $admin-config,
-        $database,
-        admin:database-fragment-root(
-          $fragment-roots[1]/db:namespace-uri,
-          $fragment-roots[1]/db:localname/fn:string(.))),
-      $database,
-      fn:subsequence($fragment-roots, 2))
-  else
-    $admin-config
+    for $root in $db-config/db:fragment-roots/db:fragment-root
+    return
+      admin:database-fragment-root(
+        $root/db:namespace-uri,
+        $root/db:localname/fn:string(.)
+      )
+  )
 };
 
 declare function setup:validate-fragment-roots(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -1829,30 +1829,19 @@ declare function setup:add-field-excludes-R(
         $admin-config,
         $database,
         $field-configs[1]/db:field-name,
-        for $e in $field-configs[1]/db:excluded-elements/db:excluded-element
+        for $excluded in $field-configs[1]/db:excluded-elements/db:excluded-element
         return
-          if (fn:starts-with(xdmp:version(), "4")) then
-            admin:database-excluded-element(
-              $e/db:namespace-uri,
-              $e/db:localname/fn:string(.))
-          else
-            xdmp:eval(
-             'import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-              declare namespace db="http://marklogic.com/xdmp/database";
-              declare variable $e external;
-
-              admin:database-excluded-element(
-                $e/db:namespace-uri,
-                $e/db:localname/fn:string(.),
-                ($e/db:attribute-namespace-uri, "")[1],
-                ($e/db:attribute-localname/fn:string(.), "")[1],
-                ($e/db:attribute-value, "")[1])',
-              (xs:QName("e"), $e),
-              <options xmlns="xdmp:eval">
-                <isolation>same-statement</isolation>
-              </options>)),
+          admin:database-excluded-element(
+            $excluded/db:namespace-uri,
+            $excluded/db:localname/fn:string(.),
+            ($excluded/db:attribute-namespace-uri, "")[1],
+            ($excluded/db:attribute-localname/fn:string(.), "")[1],
+            ($excluded/db:attribute-value, "")[1]
+          )
+      ),
       $database,
-      fn:subsequence($field-configs, 2))
+      fn:subsequence($field-configs, 2)
+    )
   else
     $admin-config
 };

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2410,32 +2410,12 @@ declare function setup:remove-existing-geospatial-element-indexes(
 
 declare function setup:validate-range-field-indexes($admin-config, $database, $db-config)
 {
-  try
-  {
-    let $existing :=
-      xdmp:eval('
-        import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-
-        declare namespace db="http://marklogic.com/xdmp/database";
-
-        declare variable $admin-config external;
-        declare variable $database external;
-
-        admin:database-get-range-field-indexes($admin-config, $database)',
-        (xs:QName("admin-config"), $admin-config,
-         xs:QName("database"), $database))
-    for $expected in $db-config/db:range-field-indexes/db:range-field-index
-    return
-      if ($existing[fn:deep-equal(., $expected)]) then ()
-      else
-        setup:validation-fail(fn:concat("Database mismatched range field index: ", $expected/db:field-name))
-  }
-  catch($ex)
-  {
-    if ($ex/error:code = "XDMP-UNDFUN") then $admin-config
+  let $existing := admin:database-get-range-field-indexes($admin-config, $database)
+  for $expected in $db-config/db:range-field-indexes/db:range-field-index
+  return
+    if ($existing[fn:deep-equal(., $expected)]) then ()
     else
-      xdmp:rethrow()
-  }
+      setup:validation-fail(fn:concat("Database mismatched range field index: ", $expected/db:field-name))
 };
 
 declare function setup:add-geospatial-element-indexes(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2396,12 +2396,21 @@ declare function setup:add-range-field-indexes-helper(
       $database,
       for $index in $db-config/db:range-field-indexes/db:range-field-index
       return
-        admin:database-range-field-index(
-          $index/db:scalar-type,
-          $index/db:field-name,
-          $index/db:collation,
-          $index/db:range-value-positions
-        )
+        if (setup:at-least-version("6.0-0")) then
+          admin:database-range-field-index(
+            $index/db:scalar-type,
+            $index/db:field-name,
+            $index/db:collation,
+            $index/db:range-value-positions,
+            $index/db:invalid-values
+          )
+        else
+          admin:database-range-field-index(
+            $index/db:scalar-type,
+            $index/db:field-name,
+            $index/db:collation,
+            $index/db:range-value-positions
+          )
     )
   else
     $admin-config

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2384,7 +2384,7 @@ declare function setup:add-range-field-indexes-helper(
           admin:database-range-field-index(
             $index/db:scalar-type,
             $index/db:field-name,
-            $index/db:collation,
+            ($index/db:collation/fn:string(), "")[1], (: ML6 requires xs:string; later requires xs:string? :)
             $index/db:range-value-positions,
             $index/db:invalid-values
           )
@@ -2647,7 +2647,7 @@ declare function setup:add-word-lexicons(
     setup:remove-existing-word-lexicons($admin-config, $database),
     $database,
     for $lex in $db-config/db:word-lexicons/db:word-lexicon
-    return admin:database-word-lexicon($lex/db:collation)
+    return admin:database-word-lexicon($lex/fn:string())
   )
 };
 

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2249,8 +2249,16 @@ declare function setup:add-phrase-throughs(
   $database as xs:unsignedLong,
   $db-config as element(db:database)) as element(configuration)
 {
-  admin:database-add-phrase-through(setup:remove-existing-phrase-throughs($admin-config, $database),
-    $database, $db-config/db:phrase-throughs/db:phrase-through)
+  admin:database-add-phrase-through(
+    setup:remove-existing-phrase-throughs($admin-config, $database),
+    $database,
+    for $pt in $db-config/db:phrase-throughs/db:phrase-through
+    return
+      admin:database-phrase-through(
+        $pt/db:namespace-uri,
+        $pt/db:localname
+      )
+  )
 };
 
 declare function setup:validate-phrase-throughs($admin-config, $database, $db-config)
@@ -2279,7 +2287,13 @@ declare function setup:add-phrase-arounds(
   admin:database-add-phrase-around(
     setup:remove-existing-phrase-arounds($admin-config, $database),
     $database,
-    $db-config/db:phrase-arounds/db:phrase-around)
+    for $pa in $db-config/db:phrase-arounds/db:phrase-around
+    return
+      admin:database-phrase-around(
+        $pa/db:namespace-uri,
+        $pa/db:collation
+      )
+    )
 };
 
 declare function setup:validate-phrase-arounds($admin-config, $database, $db-config)

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2391,18 +2391,18 @@ declare function setup:add-range-field-indexes-helper(
   $db-config as element(db:database)) as element(configuration)
 {
   if ($db-config/db:range-field-indexes/db:range-field-index) then
-    xdmp:eval('
-      import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-      declare namespace db="http://marklogic.com/xdmp/database";
-      declare variable $admin-config external;
-      declare variable $database external;
-      declare variable $db-config external;
-      admin:database-add-range-field-index($admin-config, $database, $db-config/db:range-field-indexes/db:range-field-index)',
-      (
-        xs:QName("admin-config"), $admin-config,
-        xs:QName("database"), $database,
-        xs:QName("db-config"), $db-config
-      ))
+    admin:database-add-range-field-index(
+      $admin-config,
+      $database,
+      for $index in $db-config/db:range-field-indexes/db:range-field-index
+      return
+        admin:database-range-field-index(
+          $index/db:scalar-type,
+          $index/db:field-name,
+          $index/db:collation,
+          $index/db:range-value-positions
+        )
+    )
   else
     $admin-config
 };
@@ -5739,7 +5739,7 @@ declare function setup:create-ssl-certificate-templates($import-config as elemen
           <isolation>different-transaction</isolation>
         </options>
       ),
-      
+
       xdmp:eval(
       '
       import module namespace pki = "http://marklogic.com/xdmp/pki" at "/MarkLogic/pki.xqy";

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2159,8 +2159,17 @@ declare function setup:add-element-word-lexicons(
   $database as xs:unsignedLong,
   $db-config as element(db:database)) as element(configuration)
 {
-  admin:database-add-element-word-lexicon(setup:remove-existing-element-word-lexicons($admin-config, $database),
-    $database, $db-config/db:element-word-lexicons/db:element-word-lexicon)
+  admin:database-add-element-word-lexicon(
+    setup:remove-existing-element-word-lexicons($admin-config, $database),
+    $database,
+    for $lex in $db-config/db:element-word-lexicons/db:element-word-lexicon
+    return
+      admin:database-element-word-lexicon(
+        $lex/db:namespace-uri,
+        $lex/db:localname,
+        $lex/db:collation
+      )
+    )
 };
 
 declare function setup:validate-element-word-lexicons($admin-config, $database, $db-config)

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2534,7 +2534,33 @@ declare function setup:add-geospatial-element-pair-indexes(
   admin:database-add-geospatial-element-pair-index(
     setup:remove-existing-geospatial-element-pair-indexes($admin-config, $database),
     $database,
-    $db-config/db:geospatial-element-pair-indexes/db:geospatial-element-pair-index)
+    for $index in $db-config/db:geospatial-element-pair-indexes/db:geospatial-element-pair-index
+    return
+      if (setup:at-least-version("6.0-0")) then
+        admin:database-geospatial-element-pair-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:latitude-namespace-uri,
+          $index/db:latitude-localname,
+          $index/db:longitude-namespace-uri,
+          $index/db:longitude-localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:invalid-values, "ignore")[1]
+        )
+      else
+        admin:database-geospatial-element-pair-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:latitude-namespace-uri,
+          $index/db:latitude-localname,
+          $index/db:longitude-namespace-uri,
+          $index/db:longitude-localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:invalid-values, "ignore")[1]
+        )
+  )
 };
 
 declare function setup:validate-geospatial-element-pair-indexes(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2715,29 +2715,16 @@ declare function setup:add-fragment-parents(
   $database as xs:unsignedLong,
   $db-config as element(db:database)) as element(configuration)
 {
-  setup:add-fragment-parents-R(
+  admin:database-add-fragment-parent(
     setup:remove-existing-fragment-parents($admin-config, $database),
     $database,
-    $db-config/db:fragment-parents/db:fragment-parent)
-};
-
-declare function setup:add-fragment-parents-R(
-  $admin-config as element(configuration),
-  $database as xs:unsignedLong,
-  $fragment-parents as element(db:fragment-parent)*) as element(configuration)
-{
-  if ($fragment-parents) then
-    setup:add-fragment-parents-R(
-      admin:database-add-fragment-parent(
-        $admin-config,
-        $database,
-        admin:database-fragment-parent(
-          $fragment-parents[1]/db:namespace-uri,
-          $fragment-parents[1]/db:localname/fn:string(.))),
-      $database,
-      fn:subsequence($fragment-parents, 2))
-  else
-    $admin-config
+    for $parent in $db-config/db:fragment-parents/db:fragment-parent
+    return
+      admin:database-fragment-parent(
+        $parent/db:namespace-uri,
+        $parent/db:localname
+      )
+  )
 };
 
 declare function setup:validate-fragment-parents(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2557,8 +2557,7 @@ declare function setup:add-geospatial-element-pair-indexes(
           $index/db:longitude-namespace-uri,
           $index/db:longitude-localname,
           $index/db:coordinate-system,
-          $index/db:range-value-positions,
-          ($index/db:invalid-values, "ignore")[1]
+          $index/db:range-value-positions
         )
   )
 };
@@ -2592,7 +2591,30 @@ declare function setup:add-geospatial-element-child-indexes(
   admin:database-add-geospatial-element-child-index(
     setup:remove-existing-geospatial-element-child-indexes($admin-config, $database),
     $database,
-    $db-config/db:geospatial-element-child-indexes/db:geospatial-element-child-index)
+    for $index in $db-config/db:geospatial-element-child-indexes/db:geospatial-element-child-index
+    return
+      if (setup:at-least-version("6.0-0")) then
+        admin:database-geospatial-element-child-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:namespace-uri,
+          $index/db:localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:point-format, "point")[1],
+          ($index/db:invalid-values, "ignore")[1]
+        )
+      else
+        admin:database-geospatial-element-child-index(
+          $index/db:parent-namespace-uri,
+          $index/db:parent-localname,
+          $index/db:namespace-uri,
+          $index/db:localname,
+          $index/db:coordinate-system,
+          $index/db:range-value-positions,
+          ($index/db:point-format, "point")[1]
+        )
+  )
 };
 
 declare function setup:validate-geospatial-element-child-indexes(
@@ -2624,7 +2646,9 @@ declare function setup:add-word-lexicons(
   admin:database-add-word-lexicon(
     setup:remove-existing-word-lexicons($admin-config, $database),
     $database,
-    $db-config/db:word-lexicons/db:word-lexicon)
+    for $lex in $db-config/db:word-lexicons/db:word-lexicon
+    return admin:database-word-lexicon($lex/db:collation)
+  )
 };
 
 declare function setup:validate-word-lexicons(

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -2678,7 +2678,7 @@ declare function setup:add-fragment-roots(
   $db-config as element(db:database)) as element(configuration)
 {
   admin:database-add-fragment-root(
-    $admin-config,
+    setup:remove-existing-fragment-roots($admin-config, $database),
     $database,
     for $root in $db-config/db:fragment-roots/db:fragment-root
     return

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -275,6 +275,7 @@
           <field-name>sample</field-name>
           <collation/>
           <range-value-positions>false</range-value-positions>
+          <invalid-values>ignore</invalid-values>
         </range-field-index>
 -->
       </range-field-indexes>


### PR DESCRIPTION
This ended up being bigger than I expected, but I think the changes are all things we've discussed before. Wherever we were previously relying on having the correct structure in ml-config.xml, the code now calls the appropriate admin function to build a proper structure. 

While I was at it, I replaced several try/catch and xdmp:evals with xdmp:value, as @RobertSzkutak and I discussed previously. 