### PR TITLE
issue #736: fix CTRL-EXT from a filesystem modules DB

### DIFF
--- a/src/app/config/config.xqy
+++ b/src/app/config/config.xqy
@@ -68,7 +68,7 @@ declare variable $c:ROXY-ROUTES :=
  :
  : ***********************************************
  :)
-declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[1];
+declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[fn:not(. eq "@ml.controller-ext")][1];
 
 (:
  : ***********************************************


### PR DESCRIPTION
This fixes #736 by filtering out the `@ml...` string which is present when running from the filesystem.