### PR TITLE
Fixes issue 738: fast user/role retrieval

### DIFF
--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4742,6 +4742,10 @@ declare function setup:validate-external-security(
 declare function setup:create-roles(
   $import-config as element(configuration))
 {
+  (: get the existing role names from the default security DB :)
+  let $existing-role-names := setup:get-existing-role-names()
+  return
+
   (: Create all missing roles :)
   for $role in $import-config/sec:roles/sec:role
   let $role-name as xs:string := $role/sec:role-name
@@ -4754,7 +4758,7 @@ declare function setup:create-roles(
     </options>
   return
     (: if the role exists, then don't create it :)
-    if (setup:get-roles(())/sec:role[sec:role-name = $role-name]) then ()
+    if ($existing-role-names[. = $role-name]) then ()
     else
     (
       xdmp:eval(
@@ -4911,6 +4915,10 @@ declare function setup:create-roles(
 declare function setup:validate-roles(
   $import-config as element(configuration))
 {
+  (: get the existing role names from the default security DB :)
+  let $existing-role-names := setup:get-existing-role-names()
+  return
+
   for $role in $import-config/sec:roles/sec:role
   let $role-name as xs:string := $role/sec:role-name
   let $description as xs:string? := $role/sec:description
@@ -4921,7 +4929,7 @@ declare function setup:validate-roles(
   let $privileges as element(sec:privilege)* := $role/sec:privileges/sec:privilege
   let $amps as element(sec:amp)* := $role/sec:amps/*
   let $external-names as xs:string* := $role/sec:external-names/sec:external-name
-  let $match := setup:get-roles(())/sec:role[sec:role-name = $role-name]
+  let $match := $existing-role-names[. = $role-name]
   return
     if ($match) then
       if ($match/sec:role-name != $role-name or
@@ -4964,6 +4972,11 @@ declare function setup:associate-users-with-roles($import-config as element(conf
 
 declare function setup:create-users($import-config as element(configuration))
 {
+  (: get the existing user names from the default security DB :)
+  let $existing-user-names := setup:get-existing-user-names()
+  return
+
+  (: Create all missing users :)
   for $user in $import-config/sec:users/sec:user
   let $user-name as xs:string := $user/sec:user-name
   let $description as xs:string? := $user/sec:description
@@ -4978,7 +4991,7 @@ declare function setup:create-users($import-config as element(configuration))
       <isolation>different-transaction</isolation>
     </options>
   return
-    if (setup:get-users(())/sec:user[sec:user-name = $user-name]) then
+    if ($existing-user-names[. = $user-name]) then
     (
       xdmp:eval(
         'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
@@ -5088,6 +5101,10 @@ declare function setup:create-users($import-config as element(configuration))
 
 declare function setup:validate-users($import-config as element(configuration))
 {
+  (: get the existing user names from the default security DB :)
+  let $existing-user-names := setup:get-existing-user-names()
+  return
+
   for $user in $import-config/sec:users/sec:user
   let $user-name as xs:string := $user/sec:user-name
   let $description as xs:string? := $user/sec:description
@@ -5096,7 +5113,7 @@ declare function setup:validate-users($import-config as element(configuration))
   let $permissions as element(sec:permission)* := $user/sec:permissions/*
   let $collections as xs:string* := $user/sec:collections/*
   let $external-names as xs:string* := $user/sec:external-names/sec:external-name
-  let $match := setup:get-users(())/sec:user[sec:user-name = $user-name]
+  let $match := $existing-user-names[. = $user-name]
   return
     if ($match) then
       if ($match/sec:description != $description or
@@ -5451,6 +5468,19 @@ declare function setup:get-privilege-by-name($name as xs:string) as element(sec:
     </options>)
 };
 
+(: Gets the user names from the default security database :)
+declare function setup:get-existing-user-names() as element(sec:user-name)* {
+  let $user-names :=
+    xdmp:eval(
+      'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
+       /sec:user',
+       (),
+       <options xmlns="xdmp:eval">
+        <database>{$default-security}</database>
+       </options>)/sec:user-name
+  return $user-names
+};
+
 declare function setup:get-users-by-name($names as xs:string*) as element(sec:users)? {
   let $ids :=
     for $name in $names
@@ -5528,6 +5558,19 @@ declare function setup:get-user-id($user-name as xs:string) as xs:unsignedLong? 
      <options xmlns="xdmp:eval">
        <database>{$default-security}</database>
      </options>)
+};
+
+(: Gets the role names from the default security database :)
+declare function setup:get-existing-role-names() as element(sec:role-name)* {
+  let $role-names :=
+    xdmp:eval(
+        'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
+        /sec:role',
+        (),
+        <options xmlns="xdmp:eval">
+          <database>{$default-security}</database>
+        </options>)/sec:role-name
+  return $role-names
 };
 
 declare function setup:get-roles-by-name($roles as xs:string*) as element(sec:roles)? {

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4916,7 +4916,7 @@ declare function setup:validate-roles(
   $import-config as element(configuration))
 {
   (: get the existing role names from the default security DB :)
-  let $existing-role-names := setup:get-existing-role-names()
+  let $existing-roles := setup:get-roles(())
   return
 
   for $role in $import-config/sec:roles/sec:role
@@ -4929,7 +4929,7 @@ declare function setup:validate-roles(
   let $privileges as element(sec:privilege)* := $role/sec:privileges/sec:privilege
   let $amps as element(sec:amp)* := $role/sec:amps/*
   let $external-names as xs:string* := $role/sec:external-names/sec:external-name
-  let $match := $existing-role-names[. = $role-name]
+  let $match := $existing-roles/sec:role[sec:role-name = $role-name]
   return
     if ($match) then
       if ($match/sec:role-name != $role-name or
@@ -5101,8 +5101,8 @@ declare function setup:create-users($import-config as element(configuration))
 
 declare function setup:validate-users($import-config as element(configuration))
 {
-  (: get the existing user names from the default security DB :)
-  let $existing-user-names := setup:get-existing-user-names()
+  (: get the existing users from the default security DB :)
+  let $existing-users := setup:get-users(())
   return
 
   for $user in $import-config/sec:users/sec:user
@@ -5113,7 +5113,7 @@ declare function setup:validate-users($import-config as element(configuration))
   let $permissions as element(sec:permission)* := $user/sec:permissions/*
   let $collections as xs:string* := $user/sec:collections/*
   let $external-names as xs:string* := $user/sec:external-names/sec:external-name
-  let $match := $existing-user-names[. = $user-name]
+  let $match := $existing-users/sec:user[sec:user-name = $user-name]
   return
     if ($match) then
       if ($match/sec:description != $description or

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -4744,7 +4744,6 @@ declare function setup:create-roles(
 {
   (: get the existing role names from the default security DB :)
   let $existing-role-names := setup:get-existing-role-names()
-  return
 
   (: Create all missing roles :)
   for $role in $import-config/sec:roles/sec:role
@@ -4917,7 +4916,6 @@ declare function setup:validate-roles(
 {
   (: get the existing role names from the default security DB :)
   let $existing-roles := setup:get-roles(())
-  return
 
   for $role in $import-config/sec:roles/sec:role
   let $role-name as xs:string := $role/sec:role-name
@@ -4974,7 +4972,6 @@ declare function setup:create-users($import-config as element(configuration))
 {
   (: get the existing user names from the default security DB :)
   let $existing-user-names := setup:get-existing-user-names()
-  return
 
   (: Create all missing users :)
   for $user in $import-config/sec:users/sec:user
@@ -5103,7 +5100,6 @@ declare function setup:validate-users($import-config as element(configuration))
 {
   (: get the existing users from the default security DB :)
   let $existing-users := setup:get-users(())
-  return
 
   for $user in $import-config/sec:users/sec:user
   let $user-name as xs:string := $user/sec:user-name
@@ -5564,12 +5560,12 @@ declare function setup:get-user-id($user-name as xs:string) as xs:unsignedLong? 
 declare function setup:get-existing-role-names() as element(sec:role-name)* {
   let $role-names :=
     xdmp:eval(
-        'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
+      'import module namespace sec="http://marklogic.com/xdmp/security" at "/MarkLogic/security.xqy";
         /sec:role',
-        (),
-        <options xmlns="xdmp:eval">
-          <database>{$default-security}</database>
-        </options>)/sec:role-name
+      (),
+      <options xmlns="xdmp:eval">
+        <database>{$default-security}</database>
+      </options>)/sec:role-name
   return $role-names
 };
 


### PR DESCRIPTION
Previously, bootstrapping a project with many users 
and roles was slow. The slowness was due to retrieval
of entire existing role/user elements in order to 
compare just the name.

Creating users and roles now retrieves only relevant 
role-name/user-name. 