### PR TITLE
issue #740: make -EXT work from modules and filesystem

### DIFF
--- a/src/app/config/config.xqy
+++ b/src/app/config/config.xqy
@@ -68,7 +68,7 @@ declare variable $c:ROXY-ROUTES :=
  :
  : ***********************************************
  :)
-declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[fn:not(. eq "@ml.controller-ext")][1];
+declare variable $c:CTRL-EXT := ("@ml.controller-ext", $def:CTRL-EXT)[fn:not(. eq "@" || "ml.controller-ext")][1];
 
 (:
  : ***********************************************


### PR DESCRIPTION
This separates the `@ml.controller-ext` string so it does not get processed by the roxy `deploy modules` command.