### PR TITLE
Fixed #758: Fixed encoding of amp in Roxy rewriter lib

### DIFF
--- a/src/roxy/lib/rewriter-lib.xqy
+++ b/src/roxy/lib/rewriter-lib.xqy
@@ -184,7 +184,7 @@ declare function rewriter:rewrite(
 
             return (
               if ($has-params or $i gt 1)
-                then "&amp;amp;"
+                then "&amp;"
                 else "?",
               subsequence($step-names,$i,1),
               "=",


### PR DESCRIPTION
Fixed #758 